### PR TITLE
Install software dependencies in install script

### DIFF
--- a/cmd/install
+++ b/cmd/install
@@ -1,5 +1,22 @@
 #!/bin/bash -e
 
+# Install core dependencies
+apt-get update
+apt-get install python3 openvswitch-common openvswitch-switch ca-certificates curl gnupg
+
+# TODO: Check if device is running glinux (External repositories not allowed)
+# Install docker
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Setup Python dependencies
 python3 -m venv venv
 
 source venv/bin/activate


### PR DESCRIPTION
@noursaidi Could you try this out? The cmd/install script will no longer work on gLinux as it does not support adding other repositories (docker). 