### PR TITLE
Hotfix soft launch bugs

### DIFF
--- a/cmd/package
+++ b/cmd/package
@@ -53,4 +53,4 @@ cp -r {framework,modules} $MAKE_SRC_DIR/usr/local/testrun
 dpkg-deb --build --root-owner-group make
 
 # Rename the .deb file
-mv make.deb testrun_1-0_amd64.deb
+mv make.deb testrun_1-0-1_amd64.deb

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -48,6 +48,7 @@ class TestRunSession():
     self._load_config()
 
   def start(self):
+    self.reset()
     self._status = 'Waiting for Device'
     self._started = datetime.datetime.now()
 
@@ -217,10 +218,8 @@ class TestRunSession():
   def reset(self):
     self.set_status('Idle')
     self.set_target_device(None)
-    self._tests = {
-      'total': 0,
-      'results': []
-    }
+    self._total_tests = 0
+    self._results = []
     self._started = None
     self._finished = None
 

--- a/framework/python/src/common/testreport.py
+++ b/framework/python/src/common/testreport.py
@@ -34,11 +34,10 @@ root_dir = os.path.dirname(os.path.dirname(
 report_resource_dir = os.path.join(root_dir,
                                     RESOURCES_DIR)
 
-font_file = os.path.join(report_resource_dir,'GoogleSans-Regular.ttf')
-test_run_img_file = os.path.join(report_resource_dir,'testrun.png')
+test_run_img_file = os.path.join(report_resource_dir, 'testrun.png')
 
 class TestReport():
-  """Represents a previous Test Run report."""
+  """Represents a previous Testrun report."""
 
   def __init__(self,
                status='Non-Compliant',
@@ -52,6 +51,7 @@ class TestReport():
     self._finished = finished
     self._total_tests = total_tests
     self._results = []
+    self._report_url = ''
 
   def get_status(self):
     return self._status
@@ -80,6 +80,7 @@ class TestReport():
     report_json['finished'] = self._finished.strftime(DATE_TIME_FORMAT)
     report_json['tests'] = {'total': self._total_tests,
                             'results': self._results}
+    report_json['report'] = self._report_url
     return report_json
 
   def from_json(self, json_file):
@@ -88,12 +89,15 @@ class TestReport():
     self._device['manufacturer'] = json_file['device']['manufacturer']
     self._device['model'] = json_file['device']['model']
 
-    if 'firmware' in self._device:
+    if 'firmware' in json_file['device']:
       self._device['firmware'] = json_file['device']['firmware']
 
     self._status = json_file['status']
     self._started = datetime.strptime(json_file['started'], DATE_TIME_FORMAT)
     self._finished = datetime.strptime(json_file['finished'], DATE_TIME_FORMAT)
+
+    if 'report' in json_file:
+      self._report_url = json_file['report']
     self._total_tests = json_file['tests']['total']
 
     # Loop through test results

--- a/framework/python/src/common/testreport.py
+++ b/framework/python/src/common/testreport.py
@@ -166,7 +166,8 @@ class TestReport():
     return pages
 
   def generate_page(self,json_data, page_num, max_page):
-    version = 'v1.0 (2023-10-02)' # Place holder until available in json report
+    # Placeholder until available in json report
+    version = 'v1.0.1 (2023-10-02)'
     page = '<div class="page">'
     page += self.generate_header(json_data)
     if page_num == 1:

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -354,7 +354,6 @@ class TestOrchestrator:
         module_results = module_results_json["results"]
         for test_result in module_results:
           self._session.add_test_result(test_result)
-          self._session.add_total_tests(1)
     except (FileNotFoundError, PermissionError,
             json.JSONDecodeError) as results_error:
       LOGGER.error(

--- a/make/DEBIAN/control
+++ b/make/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Testrun
-Version: 1.0
+Version: 1.0.1
 Architecture: amd64
 Maintainer: Google <boddey@google.com>
 Homepage: https://github.com/google/testrun

--- a/testing/api/test_api.py
+++ b/testing/api/test_api.py
@@ -450,7 +450,7 @@ def test_stop_running_test(testing_devices, testrun):
   r = requests.post(f"{API}/system/stop")
   response = json.loads(r.text)
   pretty_print(response)
-  assert response == {"success": "Test Run stopped"}
+  assert response == {"success": "Testrun stopped"}
   time.sleep(1)
   # Validate response
   r = requests.get(f"{API}/system/status")


### PR DESCRIPTION
Resolves the following bugs:
 - Report URL is missing in report.json
 - Total test count is double actual value
 - Firmware version is not present in report or history table
 - Test list and count is not reset when testing a second device