### PR TITLE
Bug fixes

### DIFF
--- a/modules/network/dhcp-1/python/src/grpc_server/dhcp_server.py
+++ b/modules/network/dhcp-1/python/src/grpc_server/dhcp_server.py
@@ -30,7 +30,7 @@ class DHCPServer:
     global LOGGER
     LOGGER = logger.get_logger(LOG_NAME, 'dhcp-1')
     self.dhcp_config = DHCPConfig()
-    self.radvd = RADVDServer(enabled=False)
+    self.radvd = RADVDServer(enabled=True)
     self.isc_dhcp = ISCDHCPServer()
     self.dhcp_config.resolve_config()
 

--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -439,7 +439,8 @@ class ConnectionModule(TestModule):
       if final_result is None:
         final_result = result['result']
       else:
-        final_result &= result['result']
+        if result['result'] is not None:
+          final_result &= result['result']
         if result['result']:
           final_result_details += result['details'] + '\n'
 


### PR DESCRIPTION
Corrects the following issues:

1. RADVD server disabled in DHCP-1 module blocking all IPv6 tests validation
2. None results when testing a specific subnet fails conn test module which is likely to occur when experiencing https://github.com/google/testrun/issues/104