### PR TITLE
Resolve timezone issue in connection modules

### DIFF
--- a/framework/python/src/common/device.py
+++ b/framework/python/src/common/device.py
@@ -14,8 +14,9 @@
 
 """Track device object information."""
 
-from typing import Dict
+from typing import Dict, List
 from dataclasses import dataclass, field
+from common.testreport import TestReport
 
 @dataclass
 class Device():
@@ -29,8 +30,8 @@ class Device():
   ip_addr: str = None
   firmware: str = None
   device_folder: str = None
-  reports = []
   max_device_reports: int = None
+  reports: List[TestReport] = field(default_factory=list)
 
   def add_report(self, report):
     self.reports.append(report)

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -49,7 +49,7 @@ class TestRunSession():
     tz = util.run_command('cat /etc/timezone')
     # TODO: Check if timezone is fetched successfully
     self._timezone = tz[0]
-    LOGGER.info(f'System timezone is {self._timezone}')
+    LOGGER.debug(f'System timezone is {self._timezone}')
 
   def start(self):
     self.reset()

--- a/framework/python/src/common/testreport.py
+++ b/framework/python/src/common/testreport.py
@@ -106,8 +106,6 @@ class TestReport():
     for test_result in json_file['tests']['results']:
       self.add_test(test_result)
 
-    return self
-
   # Create a pdf file in memory and return the bytes
   def to_pdf(self):
     # Resolve the data as html first

--- a/framework/python/src/core/testrun.py
+++ b/framework/python/src/core/testrun.py
@@ -162,7 +162,9 @@ class TestRun:  # pylint: disable=too-few-public-methods
         if 'max_device_reports' in device_config_json:
           max_device_reports = device_config_json.get(MAX_DEVICE_REPORTS_KEY)
 
-        device = Device(folder_url=os.path.join(device_dir, device_folder),
+        folder_url = os.path.join(device_dir, device_folder)
+
+        device = Device(folder_url=folder_url,
                         manufacturer=device_manufacturer,
                         model=device_model,
                         mac_addr=mac_addr,
@@ -170,7 +172,6 @@ class TestRun:  # pylint: disable=too-few-public-methods
                         max_device_reports=max_device_reports,
                         device_folder=device_folder)
 
-        # Load reports for this device
         self._load_test_reports(device)
 
         # Add device to device repository
@@ -178,9 +179,7 @@ class TestRun:  # pylint: disable=too-few-public-methods
         LOGGER.debug(f'Loaded device {device.manufacturer} ' +
                      f'{device.model} with MAC address {device.mac_addr}')
 
-  def _load_test_reports(self, device: Device):
-
-    LOGGER.debug(f'Loading test reports for device {device.model}')
+  def _load_test_reports(self, device):
 
     # Locate reports folder
     reports_folder = os.path.join(root_dir,
@@ -190,6 +189,8 @@ class TestRun:  # pylint: disable=too-few-public-methods
     # Check if reports folder exists (device may have no reports)
     if not os.path.exists(reports_folder):
       return
+
+    LOGGER.info(f'Loading reports from {reports_folder}')
 
     for report_folder in os.listdir(reports_folder):
       report_json_file_path = os.path.join(
@@ -204,7 +205,8 @@ class TestRun:  # pylint: disable=too-few-public-methods
 
       with open(report_json_file_path, encoding='utf-8') as report_json_file:
         report_json = json.load(report_json_file)
-        test_report = TestReport().from_json(report_json)
+        test_report = TestReport()
+        test_report.from_json(report_json)
         device.add_report(test_report)
 
   def create_device(self, device: Device):
@@ -275,10 +277,9 @@ class TestRun:  # pylint: disable=too-few-public-methods
           [NetworkEvent.DEVICE_STABLE]
       )
 
-      self._set_status('Waiting for Device')
-
     self.get_net_orc().start_listener()
     LOGGER.info('Waiting for devices on the network...')
+    self._set_status('Waiting for Device')
 
     # Keep application running until stopped
     while True:

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -100,7 +100,8 @@ class TestOrchestrator:
 
     self._session.stop()
 
-    report = TestReport().from_json(self._generate_report())
+    report = TestReport()
+    report.from_json(self._generate_report())
     device.add_report(report)
 
     self._write_reports(report)
@@ -164,7 +165,7 @@ class TestOrchestrator:
                      f"test {test_result['name']}")
         continue
       if (test_case.required_result.lower() == "required"
-          and test_result["result"].lower() == "non-compliant"):
+          and test_result["result"].lower() != "compliant"):
         result = "Non-Compliant"
     return result
 
@@ -211,7 +212,8 @@ class TestOrchestrator:
         oldest_timestamp = timestamp
         oldest_directory = completed_test
     if oldest_directory:
-      return oldest_timestamp, os.path.join(completed_tests_dir, oldest_directory)
+      return oldest_timestamp, os.path.join(completed_tests_dir,
+                                            oldest_directory)
     else:
       return None
 

--- a/modules/test/base/python/src/test_module.py
+++ b/modules/test/base/python/src/test_module.py
@@ -102,18 +102,23 @@ class TestModule:
         LOGGER.debug(f'Test {test["name"]} is disabled')
 
       if result is not None:
+        # Compliant or non-compliant
         if isinstance(result, bool):
           test['result'] = 'Compliant' if result else 'Non-Compliant'
+          test['description'] = 'No description was provided for this test'
         else:
           if result[0] is None:
-            test['result'] = 'Skipped'
+            test['result'] = 'Error'
             if len(result) > 1:
               test['description'] = result[1]
+            else:
+              test['description'] = 'An error occured whilst running this test'
           else:
             test['result'] = 'Compliant' if result[0] else 'Non-Compliant'
           test['description'] = result[1]
       else:
-        test['result'] = 'Skipped'
+        test['result'] = 'Error'
+        test['description'] = 'An error occured whilst running this test'
 
       test['end'] = datetime.now().isoformat()
       duration = datetime.fromisoformat(test['end']) - datetime.fromisoformat(

--- a/modules/test/base/python/src/test_module.py
+++ b/modules/test/base/python/src/test_module.py
@@ -108,7 +108,7 @@ class TestModule:
           test['description'] = 'No description was provided for this test'
         else:
           if result[0] is None:
-            test['result'] = 'Error'
+            test['result'] = 'Skipped'
             if len(result) > 1:
               test['description'] = result[1]
             else:
@@ -117,7 +117,7 @@ class TestModule:
             test['result'] = 'Compliant' if result[0] else 'Non-Compliant'
           test['description'] = result[1]
       else:
-        test['result'] = 'Error'
+        test['result'] = 'Skipped'
         test['description'] = 'An error occured whilst running this test'
 
       test['end'] = datetime.now().isoformat()

--- a/modules/test/baseline/conf/module_config.json
+++ b/modules/test/baseline/conf/module_config.json
@@ -1,6 +1,7 @@
 {
   "config": {
     "meta": {
+      "enabled": false,
       "name": "baseline",
       "display_name": "Baseline",
       "description": "Baseline test"
@@ -25,10 +26,10 @@
         "required_result": "Recommended"
       },
       {
-        "name": "baseline.error",
-        "test_description": "Simulate an error",
-        "expected_behavior": "A error test result is generated",
-        "required_result": "Error"
+        "name": "baseline.skipped",
+        "test_description": "Simulate a skipped test",
+        "expected_behavior": "A skipped test result is generated",
+        "required_result": "Skipped"
       }
     ]
   }

--- a/modules/test/baseline/conf/module_config.json
+++ b/modules/test/baseline/conf/module_config.json
@@ -1,7 +1,7 @@
 {
   "config": {
+    "enabled": false,
     "meta": {
-      "enabled": false,
       "name": "baseline",
       "display_name": "Baseline",
       "description": "Baseline test"

--- a/modules/test/baseline/conf/module_config.json
+++ b/modules/test/baseline/conf/module_config.json
@@ -25,10 +25,10 @@
         "required_result": "Recommended"
       },
       {
-        "name": "baseline.skipped",
-        "test_description": "Simulate a skipped test",
-        "expected_behavior": "A skipped test result is generated",
-        "required_result": "Skipped"
+        "name": "baseline.error",
+        "test_description": "Simulate an error",
+        "expected_behavior": "A error test result is generated",
+        "required_result": "Error"
       }
     ]
   }

--- a/modules/test/baseline/python/src/baseline_module.py
+++ b/modules/test/baseline/python/src/baseline_module.py
@@ -37,7 +37,7 @@ class BaselineModule(TestModule):
     LOGGER.info('Baseline non-compliant test finished')
     return False, 'Baseline non-compliant test ran successfully'
 
-  def _baseline_error(self):
-    LOGGER.info('Running baseline error test')
-    LOGGER.info('Baseline error test finished')
-    return None, 'Baseline error test ran successfully'
+  def _baseline_skipped(self):
+    LOGGER.info('Running baseline skipped test')
+    LOGGER.info('Baseline skipped test finished')
+    return None, 'Baseline skipped test ran successfully'

--- a/modules/test/baseline/python/src/baseline_module.py
+++ b/modules/test/baseline/python/src/baseline_module.py
@@ -37,7 +37,7 @@ class BaselineModule(TestModule):
     LOGGER.info('Baseline non-compliant test finished')
     return False, 'Baseline non-compliant test ran successfully'
 
-  def _baseline_skipped(self):
-    LOGGER.info('Running baseline skipped test')
-    LOGGER.info('Baseline skipped test finished')
-    return None, 'Baseline skipped test ran successfully'
+  def _baseline_error(self):
+    LOGGER.info('Running baseline error test')
+    LOGGER.info('Baseline error test finished')
+    return None, 'Baseline error test ran successfully'

--- a/modules/test/baseline/python/src/run.py
+++ b/modules/test/baseline/python/src/run.py
@@ -20,7 +20,7 @@ import logger
 
 from baseline_module import BaselineModule
 
-LOGGER = logger.get_logger('test_module')
+LOGGER = logger.get_logger('test_baseline')
 RUNTIME = 1500
 
 

--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -14,7 +14,7 @@
 """Connection test module"""
 import util
 import time
-from datetime import datetime
+import datetime
 from scapy.all import rdpcap, DHCP, Ether, IPv6, ICMPv6ND_NS
 from test_module import TestModule
 from dhcp1.client import Client as DHCPClient1
@@ -26,6 +26,7 @@ LOGGER = None
 OUI_FILE = '/usr/local/etc/oui.txt'
 STARTUP_CAPTURE_FILE = '/runtime/device/startup.pcap'
 MONITOR_CAPTURE_FILE = '/runtime/device/monitor.pcap'
+DHCP_CAPTURE_FILE = '/runtime/network/dhcp-1.pcap'
 SLAAC_PREFIX = 'fd10:77be:4186'
 TR_CONTAINER_MAC_PREFIX = '9a:02:57:1e:8f:'
 
@@ -92,9 +93,12 @@ class ConnectionModule(TestModule):
           return True, 'Device responded to leased ip address'
         else:
           return False, 'Device did not respond to leased ip address'
+      else:
+        LOGGER.info('No IP information found in lease: ' + self._device_mac)
+        return False, 'No IP information found in lease: ' + self._device_mac
     else:
-      LOGGER.info('No DHCP lease found for: ' + self._device_mac)
-      return False, 'No DHCP lease found for: ' + self._device_mac
+      LOGGER.info('Failed to query DHCP Servers for lease information: ' + self._device_mac)
+      return False, 'Failed to query DHCP Servers for lease information: ' + self._device_mac
 
   def _connection_mac_address(self):
     LOGGER.info('Running connection.mac_address')
@@ -133,7 +137,7 @@ class ConnectionModule(TestModule):
       if DHCP in packet:
         for option in packet[DHCP].options:
           # message-type, option 3 = DHCPREQUEST
-          if 'message-type' in option and option[1] == 3:
+          if 'message-type' in option and option[1] == 3: 
             mac_address = packet[Ether].src
             LOGGER.info('DHCPREQUEST detected MAC addres: ' + mac_address)
             if not mac_address.startswith(TR_CONTAINER_MAC_PREFIX):
@@ -198,6 +202,7 @@ class ConnectionModule(TestModule):
         else:
           result = None, 'Failed to create reserved lease for device'
       else:
+        LOGGER.info('Device has no current DHCP lease')
         result = None, 'Device has no current DHCP lease'
       # Restore the network
       self._dhcp_util.restore_failover_dhcp_server()
@@ -263,19 +268,10 @@ class ConnectionModule(TestModule):
   def _connection_ipv6_slaac(self):
     LOGGER.info('Running connection.ipv6_slaac')
     result = None
-    packet_capture = rdpcap(MONITOR_CAPTURE_FILE)
 
-    sends_ipv6 = False
-
-    for packet in packet_capture:
-      if IPv6 in packet and packet.src == self._device_mac:
-        sends_ipv6 = True
-        if ICMPv6ND_NS in packet:
-          ipv6_addr = str(packet[ICMPv6ND_NS].tgt)
-          if ipv6_addr.startswith(SLAAC_PREFIX):
-            self._device_ipv6_addr = ipv6_addr
-            LOGGER.info(f'Device has formed SLAAC address {ipv6_addr}')
-            result = True, f'Device has formed SLAAC address {ipv6_addr}'
+    slac_test, sends_ipv6 = self._has_slaac_addres()
+    if slac_test:
+      result = True, f'Device has formed SLAAC address {self._device_ipv6_addr}'
     if result is None:
       if sends_ipv6:
         LOGGER.info('Device does not support IPv6 SLAAC')
@@ -285,6 +281,21 @@ class ConnectionModule(TestModule):
         result = False, 'Device does not support IPv6'
     return result
 
+  def _has_slaac_addres(self):
+    packet_capture = rdpcap(DHCP_CAPTURE_FILE)
+    sends_ipv6 = False
+    for packet_number, packet in enumerate(packet_capture, start=1):
+      if IPv6 in packet and packet.src == self._device_mac:
+        sends_ipv6 = True
+        if ICMPv6ND_NS in packet:
+          ipv6_addr = str(packet[ICMPv6ND_NS].tgt)
+          if ipv6_addr.startswith(SLAAC_PREFIX):
+            self._device_ipv6_addr = ipv6_addr
+            LOGGER.info(f"SLAAC address detected at packet number {packet_number}")
+            LOGGER.info(f'Device has formed SLAAC address {ipv6_addr}')
+            return True, sends_ipv6
+    return False, sends_ipv6
+
   def _connection_ipv6_ping(self):
     LOGGER.info('Running connection.ipv6_ping')
     result = None
@@ -292,17 +303,20 @@ class ConnectionModule(TestModule):
       LOGGER.info('No IPv6 SLAAC address found. Cannot ping')
       result = False, 'No IPv6 SLAAC address found. Cannot ping'
     else:
-      if self._ping(self._device_ipv6_addr):
+      if self._ping(self._device_ipv6_addr, ipv6=True):
         LOGGER.info(f'Device responds to IPv6 ping on {self._device_ipv6_addr}')
-        result = True, ('Device responds to IPv6 ping on ' +
-                        f'{self._device_ipv6_addr}')
+        result = True, f'Device responds to IPv6 ping on {self._device_ipv6_addr}'
       else:
         LOGGER.info('Device does not respond to IPv6 ping')
         result = False, 'Device does not respond to IPv6 ping'
     return result
 
-  def _ping(self, host):
-    cmd = 'ping -c 1 ' + str(host)
+  def _ping(self, host, ipv6=False):
+    LOGGER.info('Pinging: ' + str(host))
+    cmd = 'ping -c 1 '
+    cmd += ' -6 ' if ipv6 else ''
+    cmd += str(host)
+    #cmd = 'ping -c 1 ' + str(host)
     success = util.run_command(cmd, output=False)
     return success
 
@@ -387,11 +401,23 @@ class ConnectionModule(TestModule):
     dhcp_setup = self.setup_single_dhcp_server()
     if dhcp_setup[0]:
       LOGGER.info(dhcp_setup[1])
-      lease = self._get_cur_lease()
+      # Lease timing could be in a state where
+      # is is currently reneweing so we want to
+      # pad a few tries to make sure we don't
+      # miss a valid lease state
+      for _ in range(5):
+        lease = self._get_cur_lease()
+        if lease is not None:
+          break
+        else:
+          LOGGER.debug("Lease not found")
+          time.sleep(5)
+
       if lease is not None:
         if self._is_lease_active(lease):
           results = self.test_subnets(ranges)
       else:
+        LOGGER.info("Failed to confirm a valid active lease for the device")
         return None, 'Failed to confirm a valid active lease for the device'
     else:
       LOGGER.error(dhcp_setup[1])
@@ -442,20 +468,23 @@ class ConnectionModule(TestModule):
 
   def _test_subnet(self, subnet, lease):
     if self._change_subnet(subnet):
-      expiration = datetime.strptime(lease['expires'], '%Y-%m-%d %H:%M:%S')
-      time_to_expire = expiration - datetime.now()
+      expiration = datetime.datetime.strptime(
+        lease['expires'], '%Y-%m-%d %H:%M:%S')
+      now_utc = datetime.datetime.now(
+        datetime.timezone.utc).replace(tzinfo=None)
+      time_to_expire = (expiration - now_utc).total_seconds()
       LOGGER.debug('Time until lease expiration: ' + str(time_to_expire))
       LOGGER.info('Waiting for current lease to expire: ' + str(expiration))
-      if time_to_expire.total_seconds() > 0:
-        time.sleep(time_to_expire.total_seconds() +
-                   5)  # Wait until the expiration time and padd 5 seconds
-        LOGGER.info('Current lease expired. Checking for new lease')
+      if time_to_expire > 0:
+        # Wait until the expiration time and add 5 seconds
+        time.sleep(time_to_expire + 5)
+        LOGGER.debug('Current lease expired. Checking for new lease')
         for _ in range(5):
-          LOGGER.info('Checking for new lease')
+          LOGGER.debug('Checking for new lease')
           lease = self._get_cur_lease()
           if lease is not None:
-            LOGGER.info('New lease found: ' + str(lease))
-            LOGGER.info('Validating subnet for new lease...')
+            LOGGER.debug('New lease found: ' + str(lease))
+            LOGGER.debug('Validating subnet for new lease...')
             in_range = self.is_ip_in_range(lease['ip'], subnet['start'],
                                            subnet['end'])
             LOGGER.info('Lease within subnet: ' + str(in_range))
@@ -467,8 +496,9 @@ class ConnectionModule(TestModule):
       LOGGER.error('Failed to change subnet')
 
   def _wait_for_lease_expire(self, lease):
-    expiration = datetime.strptime(lease['expires'], '%Y-%m-%d %H:%M:%S')
-    time_to_expire = expiration - datetime.now()
+    expiration = datetime.datetime.strptime(
+      lease['expires'], '%Y-%m-%d %H:%M:%S')
+    time_to_expire = expiration - datetime.datetime.now()
     LOGGER.info('Time until lease expiration: ' + str(time_to_expire))
     LOGGER.info('Waiting for current lease to expire: ' + str(expiration))
     if time_to_expire.total_seconds() > 0:
@@ -504,11 +534,11 @@ class ConnectionModule(TestModule):
   def _is_lease_active(self, lease):
     if 'ip' in lease:
       ip_addr = lease['ip']
-      LOGGER.info('Lease IP Resolved: ' + ip_addr)
+      LOGGER.info('Lease IP resolved: ' + ip_addr)
       LOGGER.info('Attempting to ping device...')
       ping_success = self._ping(self._device_ipv4_addr)
-      LOGGER.info('Ping Success: ' + str(ping_success))
-      LOGGER.info('Current lease confirmed active in device')
+      LOGGER.debug('Ping success: ' + str(ping_success))
+      LOGGER.debug('Current lease confirmed active in device')
       return ping_success
 
   def test_subnets(self, subnets):
@@ -521,18 +551,24 @@ class ConnectionModule(TestModule):
           result = self._test_subnet(subnet, lease)
           if result:
             result = {
-                'result':
-                True,
-                'details':
-                'Subnet ' + subnet['start'] + '-' + subnet['end'] + ' passed'
+              'result':
+              True,
+              'details':
+              'Subnet ' + subnet['start'] + '-' + subnet['end'] + ' passed'
             }
           else:
             result = {
-                'result':
-                False,
-                'details':
-                'Subnet ' + subnet['start'] + '-' + subnet['end'] + ' failed'
+              'result':
+              False,
+              'details':
+              'Subnet ' + subnet['start'] + '-' + subnet['end'] + ' failed'
             }
+        else:
+          result = {
+            'result': None, 
+            'details': 'Device does not have active lease, cannot test subnet change. ' + 
+            'Subnet ' + subnet['start'] + '-' + subnet['end'] + ' skipped'
+          }
       except Exception as e:  # pylint: disable=W0718
         result = {'result': False, 'details': 'Subnet test failed: ' + str(e)}
       results.append(result)

--- a/modules/test/conn/python/src/dhcp_util.py
+++ b/modules/test/conn/python/src/dhcp_util.py
@@ -134,7 +134,7 @@ class DHCPUtil():
       LOGGER.info('Checking for new lease')
       if lease is None:
         lease = self.get_cur_lease(mac_address,dhcp_server_primary)
-        LOGGER.info('New Lease found: ' + str(lease))
+        LOGGER.info('New lease found: ' + str(lease))
         break
       else:
         LOGGER.info('New lease not found. Waiting to check again')

--- a/modules/test/conn/python/src/run.py
+++ b/modules/test/conn/python/src/run.py
@@ -20,7 +20,7 @@ import logger
 
 from connection_module import ConnectionModule
 
-LOGGER = logger.get_logger('connection_module')
+LOGGER = logger.get_logger('test_connection')
 
 
 class ConnectionModuleRunner:

--- a/testing/device_configs/tester2/device_config.json
+++ b/testing/device_configs/tester2/device_config.json
@@ -10,7 +10,7 @@
       "enabled": true
     },
     "ntp": {
-      "enabled": true
+      "enabled": false
     },
     "baseline": {
       "enabled": false


### PR DESCRIPTION
Now that the timezone has been set to the local timezone within test and network containers, the test code within the connection module does not function correctly - it is expecting the local time of the container to be UTC (the same as the time zone used in the DHCP server lease file). Therefore, wait times etc are not correct. This pull request manually converts local time back to UTC time when making date time comparisons with the DHCP lease expiration times.