### PR TITLE
Fix device search issue

### DIFF
--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -174,7 +174,7 @@ class TestRunSession():
 
   def get_device(self, mac_addr):
     for device in self._device_repository:
-      if device.lower() == mac_addr.lower():
+      if device.mac_addr.lower() == mac_addr.lower():
         return device
     return None
 

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -174,7 +174,7 @@ class TestRunSession():
 
   def get_device(self, mac_addr):
     for device in self._device_repository:
-      if device.mac_addr == mac_addr:
+      if device.lower() == mac_addr.lower():
         return device
     return None
 


### PR DESCRIPTION
A Testrun cannot be started if a device is created with an uppercase MAC address. This PR ignores case when searching for a device by MAC address.