### PR TITLE
Test module timeout

### DIFF
--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -336,8 +336,11 @@ class TestOrchestrator:
     status = self._get_module_status(module)
 
     log_stream = module.container.logs(stream=True, stdout=True, stderr=True)
-    while (time.time() < test_module_timeout and status == "running"
-           and self._session.get_status() == "In Progress"):
+    while (status == "running" and self._session.get_status() == "In Progress"):
+      if time.time() > test_module_timeout:
+          LOGGER.error("Module timeout exceeded, killing module: " + module.name)
+          self._stop_module(module=module,kill=True)
+          break
       try:
         line = next(log_stream).decode("utf-8").strip()
         if re.search(LOG_REGEX, line):

--- a/modules/test/conn/conf/module_config.json
+++ b/modules/test/conn/conf/module_config.json
@@ -10,7 +10,7 @@
     "docker": {
       "depends_on": "base",
       "enable_container": true,
-      "timeout": 900
+      "timeout": 1800
     },
     "tests": [
       {

--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -465,7 +465,7 @@ class ConnectionModule(TestModule):
       LOGGER.info('Checking for new lease')
       # Subnet changes tend to take longer to pick up so we'll allow
       # for twice the lease wait time
-      lease = self._dhcp_util.get_cur_lease(mac_address=self._device_mac,timeout=2*self._lease_wait_time_sec*2)
+      lease = self._dhcp_util.get_cur_lease(mac_address=self._device_mac,timeout=2*self._lease_wait_time_sec)
       if lease is not None:
         LOGGER.info('Validating subnet for new lease...')
         in_range = self.is_ip_in_range(lease['ip'], cur_range['start'],


### PR DESCRIPTION
Partially resolves this issue:
https://github.com/google/testrun/issues/184

Does not fully deal with expected behavior within issue reported but adds a simple timeout detection and module kill process so the output and the results match.

Additional things fixed:
- Fix duplicate lease multiplier in conn module during new lease detection
- Increase conn module timeout to 30 minutes, which is 3 minutes longer than the current max timeout of all tests 