### PR TITLE
323349282: (fix) [ui] change logic to hide message if only device port is saved

### DIFF
--- a/modules/ui/src/app/store/effects.ts
+++ b/modules/ui/src/app/store/effects.ts
@@ -103,9 +103,7 @@ export class AppEffects {
       withLatestFrom(this.store.select(selectSystemConfig)),
       filter(
         ([, systemConfig]) =>
-          systemConfig.network != null &&
-          systemConfig.network.device_intf != '' &&
-          systemConfig.network.internet_intf != ''
+          systemConfig.network != null && systemConfig.network.device_intf != ''
       ),
       map(() =>
         AppActions.setHasConnectionSettings({ hasConnectionSettings: true })
@@ -120,8 +118,7 @@ export class AppEffects {
       filter(
         ([, systemConfig]) =>
           systemConfig.network == null ||
-          systemConfig.network.device_intf === '' ||
-          systemConfig.network.internet_intf === ''
+          systemConfig.network.device_intf === ''
       ),
       map(() =>
         AppActions.setHasConnectionSettings({ hasConnectionSettings: false })


### PR DESCRIPTION
### Overview

Ticket: 323349282:

fix: [ui] change logic to hide message if only device port is saved

### Video after changes:

Link: https://screencast.googleplex.com/cast/NDU2ODc5ODk5NTY3NzE4NHw3MWRkMzA0Ni1iOA

### Screenshot after changes

![image](https://github.com/google/testrun/assets/25095840/8eb065f4-d08f-4c39-ba9d-1709ac0960e2)
