### PR TITLE
314934734: (fix) [ui] [a11y] repeated instructions  announced by screen reader

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.html
+++ b/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.html
@@ -17,8 +17,8 @@ limitations under the License.
   <div
     class="progress-card"
     [ngClass]="getClass(data.status)"
-    aria-live="assertive"
-    role="alert">
+    aria-live="polite"
+    role="status">
     <div>
       <p class="progress-card-status-title">Test status</p>
       <p class="progress-card-status-text">


### PR DESCRIPTION
### Overview

Ticket: 314934734

fix [ui] [a11y] repeated instructions  announced by screen reader - change accessible attributes 

Unit tests are all passed:

![image](https://github.com/google/testrun/assets/25095840/1921432c-9b85-4263-a7a6-018b5037e509)
