### PR TITLE
Bump vite and @angular-devkit/build-angular in /modules/ui

### DIFF
--- a/modules/ui/package-lock.json
+++ b/modules/ui/package-lock.json
@@ -24,7 +24,7 @@
         "zone.js": "~0.13.3"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^16.2.11",
+        "@angular-devkit/build-angular": "^16.2.12",
         "@angular-eslint/builder": "16.2.0",
         "@angular-eslint/eslint-plugin": "16.2.0",
         "@angular-eslint/eslint-plugin-template": "16.2.0",
@@ -72,12 +72,12 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.1602.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.11.tgz",
-      "integrity": "sha512-qC1tPL/82gxqCS1z9pTpLn5NQH6uqbV6UNjbkFEQpTwEyWEK6VLChAJsybHHfbpssPS2HWf31VoUzX7RqDjoQQ==",
+      "version": "0.1602.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.12.tgz",
+      "integrity": "sha512-19Fwwfx+KvJ01SyI6cstRgqT9+cwer8Ro1T27t1JqlGyOX8tY3pV78ulwxy2+wCzPjR18V6W7cb7Cv6fyK4xog==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.11",
+        "@angular-devkit/core": "16.2.12",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -87,15 +87,15 @@
       }
     },
     "node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.11.tgz",
-      "integrity": "sha512-yNzUiAeg1WHMsFG9IBg4S/7dsMcEAMYQ1I360ib80c0T/IwRb8pHhOokrl5Mu8zfNqZ/dxH4ItKY1uIMDmuMGQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.12.tgz",
+      "integrity": "sha512-VVGKZ0N3gyR0DP7VrcZl4io3ruWYT94mrlyJsJMLlrYy/EX8JCvqrJC9c+dscrtKjhZzjwdyhszkJQY4JfwACA==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.11",
-        "@angular-devkit/build-webpack": "0.1602.11",
-        "@angular-devkit/core": "16.2.11",
+        "@angular-devkit/architect": "0.1602.12",
+        "@angular-devkit/build-webpack": "0.1602.12",
+        "@angular-devkit/core": "16.2.12",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -107,7 +107,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.11",
+        "@ngtools/webpack": "16.2.12",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -150,7 +150,7 @@
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "tslib": "2.6.1",
-        "vite": "4.5.1",
+        "vite": "4.5.2",
         "webpack": "5.88.2",
         "webpack-dev-middleware": "6.1.1",
         "webpack-dev-server": "4.15.1",
@@ -215,12 +215,12 @@
       "dev": true
     },
     "node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.11.tgz",
-      "integrity": "sha512-2Au6xRMxNugFkXP0LS1TwNE5gAfGW4g6yxC9P5j5p3kdGDnAVaZRTOKB9dg73i3uXtJHUMciYOThV0b78XRxwA==",
+      "version": "0.1602.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.12.tgz",
+      "integrity": "sha512-1lmR4jCkxPJuAFXReesEY3CB+/5jSebGE5ry6qJJvNm6kuSc9bzfTytrcwosVY+Q7kAA2ij7kAYw0loGbTjLWA==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.11",
+        "@angular-devkit/architect": "0.1602.12",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -234,9 +234,9 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.11.tgz",
-      "integrity": "sha512-u3cEQHqhSMWyAFIaPdRukCJwEUJt7Fy3C02gTlTeCB4F/OnftVFIm2e5vmCqMo9rgbfdvjWj9V+7wWiCpMrzAQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.12.tgz",
+      "integrity": "sha512-o6ziQs+EcEonFezrsA46jbZqkQrs4ckS1bAQj93g5ZjGtieUz8l/U3lclvKpL/iEzWkGVViSYuP2KyW2oqTDiQ==",
       "dev": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -3820,9 +3820,9 @@
       }
     },
     "node_modules/@ngtools/webpack": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.11.tgz",
-      "integrity": "sha512-4ndXJ4s94ZsryVGSDk/waIDrUqXqdGWftoOEn81Zu+nkL9ncI/G1fNUlSJ5OqeKmMLxMFouoy+BuJfvT+gEgnQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.12.tgz",
+      "integrity": "sha512-f9R9Qsk8v+ffDxryl6PQ7Wnf2JCNd4dDXOH+d/AuF06VFiwcwGDRDZpmqkAXbFxQfcWTbT1FFvfoJ+SFcJgXLA==",
       "dev": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -4412,9 +4412,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -14543,9 +14543,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/modules/ui/package.json
+++ b/modules/ui/package.json
@@ -33,7 +33,7 @@
     "zone.js": "~0.13.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.2.11",
+    "@angular-devkit/build-angular": "^16.2.12",
     "@angular-eslint/builder": "16.2.0",
     "@angular-eslint/eslint-plugin": "16.2.0",
     "@angular-eslint/eslint-plugin-template": "16.2.0",


### PR DESCRIPTION
Bumps [vite](https://github.com/vitejs/vite/tree/HEAD/packages/vite) to 4.5.2 and updates ancestor dependency [@angular-devkit/build-angular](https://github.com/angular/angular-cli). These dependencies need to be updated together.


Updates `vite` from 4.5.1 to 4.5.2
- [Release notes](https://github.com/vitejs/vite/releases)
- [Changelog](https://github.com/vitejs/vite/blob/v4.5.2/packages/vite/CHANGELOG.md)
- [Commits](https://github.com/vitejs/vite/commits/v4.5.2/packages/vite)

Updates `@angular-devkit/build-angular` from 16.2.11 to 16.2.12
- [Release notes](https://github.com/angular/angular-cli/releases)
- [Changelog](https://github.com/angular/angular-cli/blob/main/CHANGELOG.md)
- [Commits](https://github.com/angular/angular-cli/compare/16.2.11...16.2.12)

---
updated-dependencies:
- dependency-name: vite dependency-type: indirect
- dependency-name: "@angular-devkit/build-angular" dependency-type: direct:development ...