### PR TITLE
324864346: (fix) [a11Y] change color for field label to fix GAR 1.14 low color contrast

### DIFF
--- a/modules/ui/src/styles.scss
+++ b/modules/ui/src/styles.scss
@@ -177,6 +177,10 @@ h2.title {
   --mat-option-selected-state-layer-color: #e8f0fe;
 }
 
+.mat-mdc-form-field {
+  --mdc-outlined-text-field-focus-label-text-color: #1a73e8;
+}
+
 body:has(.initiate-test-run-dialog)
   app-root
   app-spinner.connection-settings-spinner,


### PR DESCRIPTION
### Overview

**Ticket:** 324864346
**fix:** [a11Y] change color for field label to fix GAR 1.14 low color contrast

### Screenshot before changes

![image](https://github.com/google/testrun/assets/25095840/0f8103ae-9263-4d64-9236-ada1b3114063)

### Screenshot after changes

![image](https://github.com/google/testrun/assets/25095840/e7c29643-b733-4f28-8805-933950ea476e)


