### PR TITLE
Add arp dhcp inspection ovs

### DIFF
--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -193,7 +193,7 @@ class NetworkOrchestrator:
     LOGGER.info(
         f'Device with mac addr {device.mac_addr} has obtained IP address '
         f'{device.ip_addr}')
-    self._ovs.add_arp_inspection_filter(ip_address=device.ip_addr,mac_address=device.mac_addr)
+    # self._ovs.add_arp_inspection_filter(ip_address=device.ip_addr,mac_address=device.mac_addr)
 
     self._start_device_monitor(device)
 
@@ -661,6 +661,10 @@ class NetworkOrchestrator:
           LOGGER.error('Failed to add ' + net_module.name +
                        ' to internet bridge ' + DEVICE_BRIDGE + '. Exiting.')
           sys.exit(1)
+
+  def remove_arp_filters(self):
+    LOGGER.info('Removing ARP inspection filters')
+    self._ovs.delete_arp_inspection_filter()
 
   def restore_net(self):
 

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -193,6 +193,7 @@ class NetworkOrchestrator:
     LOGGER.info(
         f'Device with mac addr {device.mac_addr} has obtained IP address '
         f'{device.ip_addr}')
+    self._ovs.add_arp_inspection_filter(ip_address=device.ip_addr,mac_address=device.mac_addr)
 
     self._start_device_monitor(device)
 

--- a/framework/python/src/net_orc/ovs_control.py
+++ b/framework/python/src/net_orc/ovs_control.py
@@ -51,6 +51,12 @@ class OVSControl:
                              add-port {bridge_name} {port}""")
     return success
 
+  def delete_flow(self, bridge_name, flow):
+    # Delete a flow from the bridge using ovs-ofctl commands
+    LOGGER.debug(f'Deleting flow {flow} from bridge: {bridge_name}')
+    success = util.run_command(f'ovs-ofctl del-flows {bridge_name} \'{flow}\'')
+    return success
+
   def get_bridge_ports(self, bridge_name):
     # Get a list of all the ports on a bridge
     response = util.run_command(f'ovs-vsctl list-ports {bridge_name}',
@@ -125,6 +131,13 @@ class OVSControl:
     self.add_flow(bridge_name=DEVICE_BRIDGE,
                   flow='table=0, dl_dst=01:80:c2:00:00:03, actions=flood')
 
+    # Add a DHCP snooping equivalent to the device bridge
+    # ToDo Define these IP's dynamically
+    dhcp_server_primary_ip = '10.10.10.2'
+    dhcp_server_secondary_ip = '10.10.10.3'
+    self.add_dhcp_filters(dhcp_server_primary_ip=dhcp_server_primary_ip,
+      dhcp_server_secondary_ip=dhcp_server_secondary_ip)
+
     # Set ports up
     self.set_bridge_up(DEVICE_BRIDGE)
     self.set_bridge_up(INTERNET_BRIDGE)
@@ -135,6 +148,50 @@ class OVSControl:
       return self.validate_baseline_network()
     else:
       return None
+
+  def add_dhcp_filters(self,dhcp_server_primary_ip,dhcp_server_secondary_ip):
+
+    # Allow DHCP traffic from primary server
+    allow_primary_dhcp_server = (
+      f'table=0, dl_type=0x800, priority=65535, tp_src=67, tp_dst=68, nw_src={dhcp_server_primary_ip}, actions=normal')
+    self.add_flow(bridge_name=DEVICE_BRIDGE,flow=allow_primary_dhcp_server)
+
+    # Allow DHCP traffic from secondary server
+    allow_secondary_dhcp_server = (
+      f'table=0, dl_type=0x800, priority=65535, tp_src=67, tp_dst=68, nw_src={dhcp_server_secondary_ip}, actions=normal')
+    self.add_flow(bridge_name=DEVICE_BRIDGE,flow=allow_secondary_dhcp_server)
+
+    # Drop DHCP packets not associated with known servers
+    drop_dhcp_flow = 'table=0, dl_type=0x800, priority=0, tp_src=67, tp_dst=68, actions=drop'
+    self.add_flow(bridge_name=DEVICE_BRIDGE,flow=drop_dhcp_flow)
+
+  def add_arp_inspection_filter(self,ip_address,mac_address):
+    # Combine IP address and MAC address
+    combined_str = ip_address + mac_address
+
+    # Convert combined string to integer
+    cookie_value = int(combined_str.replace(':', '').replace('.', ''))
+
+    # Allow ARP packets with known MAC-to-IP mappings
+    drop_bad_arp= f'table=0, cookie={cookie_value}, priority=65535, arp, arp_tpa={ip_address}, arp_tha={mac_address}, action=normal'
+    self.add_flow(bridge_name=DEVICE_BRIDGE,flow=drop_bad_arp)
+
+    # Drop ARP packets with unknown MAC-to-IP mappings
+    drop_unknown_arps = (
+        f'table=0, priority=0, arp, '
+        f'action=drop'
+    )
+    self.add_flow(bridge_name=DEVICE_BRIDGE,flow=drop_unknown_arps)
+
+  def delete_arp_inspection_filter(self,ip_address,mac_address):
+    # Combine IP address and MAC address
+    combined_str = ip_address + mac_address
+
+    # Convert combined string to integer
+    cookie_value = int(combined_str.replace(':', '').replace('.', ''))
+
+    self.delete_flow(bridge_name=DEVICE_BRIDGE,flow=f'cookie={cookie_value}')
+    
 
   def delete_bridge(self, bridge_name):
     LOGGER.debug('Deleting OVS Bridge: ' + bridge_name)

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -326,6 +326,9 @@ class TestOrchestrator:
 
       client = docker.from_env()
 
+      # if module.name == 'connection':
+      #   self._net_orc.remove_arp_filters()
+
       module.container = client.containers.run(
           module.image_name,
           auto_remove=True,


### PR DESCRIPTION
Adds DHCP filters for OVS that are equivalent to DHCP snooping only allowing our virtual network DHCP servers.

ARP inspection flows have been disabled as they appear to break gRPC working between the DHCP servers even after removing them before connection module runs.  Still needs investigation into how we can fully enable this.