### PR TITLE
325424134: (fix) change borders for results table to be visible on scrolling

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/progress-table/progress-table.component.scss
+++ b/modules/ui/src/app/pages/testrun/components/progress-table/progress-table.component.scss
@@ -21,15 +21,12 @@ $row-height: 48px;
 $row-horizontal-padding: 16px;
 $expander-button-size: 28px;
 
-:host {
-  overflow-y: auto;
-  margin: 16px 0;
-}
-
 .tests-container {
   display: block;
-  border: 1px solid $lighter-grey;
-  border-bottom: none;
+
+  & > :last-child {
+    border-bottom: none;
+  }
 }
 
 .tests-header-row {

--- a/modules/ui/src/app/pages/testrun/progress.component.scss
+++ b/modules/ui/src/app/pages/testrun/progress.component.scss
@@ -100,7 +100,9 @@
 .progress-table {
   overflow-y: auto;
   flex: 1;
-  padding-top: 10px;
+  margin: 10px 0;
+  border-radius: 4px;
+  border: 1px solid $lighter-grey;
   & ::ng-deep .loader {
     width: 196px;
     height: 196px;


### PR DESCRIPTION
### Overview

**Ticket:** 325424134
**fix: [styles]** change borders for results table to be visible on scrolling

### Screenshot before changes

![image](https://github.com/google/testrun/assets/25095840/49f23977-81d9-4265-a061-1021480fc56a)

### Screenshot after changes

![image](https://github.com/google/testrun/assets/25095840/62808ef9-4ff2-42d0-9803-8b63fe378990)
