### PR TITLE
327161779: (fix) change get status with finished data to display a proper status on status bar

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.spec.ts
+++ b/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.spec.ts
@@ -171,6 +171,17 @@ describe('ProgressStatusCardComponent', () => {
 
         expect(result).toEqual(expectedResult);
       });
+
+      it('should return test status "Monitoring" if finished with status "Monitoring"', () => {
+        const MOCK_MONITORING_FINISHED_DATA = {
+          ...MOCK_PROGRESS_DATA_MONITORING,
+          finished: '2023-06-22T09:20:00.123Z',
+        };
+
+        const result = component.getTestStatus(MOCK_MONITORING_FINISHED_DATA);
+
+        expect(result).toEqual(StatusOfTestrun.Monitoring);
+      });
     });
 
     describe('#getProgressValue', () => {

--- a/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.ts
+++ b/modules/ui/src/app/pages/testrun/components/progress-status-card/progress-status-card.component.ts
@@ -40,10 +40,7 @@ export class ProgressStatusCardComponent {
     canceled: boolean;
   } {
     return {
-      progress:
-        status === StatusOfTestrun.InProgress ||
-        status === StatusOfTestrun.WaitingForDevice ||
-        status === StatusOfTestrun.Monitoring,
+      progress: this.isProgressStatus(status),
       'completed-success':
         status === StatusOfTestrun.Compliant ||
         status === StatusOfTestrun.CompliantLimited ||
@@ -80,13 +77,21 @@ export class ProgressStatusCardComponent {
   }
 
   public getTestStatus(data: TestrunStatus): string {
-    if (data.finished) {
-      return 'Complete';
-    } else if (data.status === StatusOfTestrun.Cancelled) {
+    if (data.status === StatusOfTestrun.Cancelled) {
       return 'Incomplete';
+    } else if (data.finished && !this.isProgressStatus(data.status)) {
+      return 'Complete';
     } else {
       return data.status;
     }
+  }
+
+  private isProgressStatus(status: string): boolean {
+    return (
+      status === StatusOfTestrun.Monitoring ||
+      status === StatusOfTestrun.InProgress ||
+      status === StatusOfTestrun.WaitingForDevice
+    );
   }
 
   public getProgressValue(data: TestrunStatus): number {

--- a/modules/ui/src/app/pages/testrun/progress.component.scss
+++ b/modules/ui/src/app/pages/testrun/progress.component.scss
@@ -99,7 +99,6 @@
 
 .progress-table {
   overflow-y: auto;
-  flex: 1;
   margin: 10px 0;
   border-radius: 4px;
   border: 1px solid $lighter-grey;


### PR DESCRIPTION
### Overview

**Ticket:** 327161779
**fix:** change get status with finished data to display a proper status on status bar

### Screenshots after changes (with finished property of data)

![image](https://github.com/google/testrun/assets/25095840/f998b352-71be-4d56-9443-b73a449a8d93)

![image](https://github.com/google/testrun/assets/25095840/58f18388-514e-45c2-be62-4d34dc6a7133)

![image](https://github.com/google/testrun/assets/25095840/48c0358a-bfd5-417a-a0a5-5ae4251c9293)


### Screenshots before changes (with finished property of data)

![image](https://github.com/google/testrun/assets/25095840/5d3a2296-a4a1-4840-a29d-e1faab55fcbc)

![image](https://github.com/google/testrun/assets/25095840/25c9413f-bf3d-4cde-8140-def73a2c26cd)

![image](https://github.com/google/testrun/assets/25095840/de5bd98f-1a6c-4f70-872f-3bd39afeb90b)

![image](https://github.com/google/testrun/assets/25095840/4a32d689-097b-4240-a876-c8ae8096ee8b)
