### PR TITLE
330699330: (fix) change styles to prevent unexpected space on pages with welcome modal

### DIFF
--- a/modules/ui/src/styles.scss
+++ b/modules/ui/src/styles.scss
@@ -198,26 +198,35 @@ body:has(.filter-dialog-content)
   opacity: 0;
 }
 
-body:has(app-callout .info):not(:has(app-callout .error))
+body
+  #main:has(app-callout .info):not(:has(app-callout .error))
   app-device-repository:not(:has(.device-repository-content-empty)),
-body:has(app-callout .info):not(:has(app-callout .error))
+body
+  #main:has(app-callout .info):not(:has(app-callout .error))
   app-history:not(:has(.results-content-empty)),
-body:has(app-callout .info):not(:has(app-callout .error))
+body
+  #main:has(app-callout .info):not(:has(app-callout .error))
   app-progress:not(:has(.progress-content-empty)),
-body:has(app-callout .error):not(:has(app-callout .info))
+body
+  #main:has(app-callout .error):not(:has(app-callout .info))
   app-device-repository:not(:has(.device-repository-content-empty)),
-body:has(app-callout .error):not(:has(app-callout .info))
+body
+  #main:has(app-callout .error):not(:has(app-callout .info))
   app-history:not(:has(.results-content-empty)),
-body:has(app-callout .error):not(:has(app-callout .info))
+body
+  #main:has(app-callout .error):not(:has(app-callout .info))
   app-progress:not(:has(.progress-content-empty)) {
   margin-top: 96px;
 }
 
-body:has(app-callout .info):has(app-callout .error)
+body
+  #main:has(app-callout .info):has(app-callout .error)
   app-device-repository:not(:has(.device-repository-content-empty)),
-body:has(app-callout .info):has(app-callout .error)
+body
+  #main:has(app-callout .info):has(app-callout .error)
   app-history:not(:has(.results-content-empty)),
-body:has(app-callout .info):has(app-callout .error)
+body
+  #main:has(app-callout .info):has(app-callout .error)
   app-progress:not(:has(.progress-content-empty)) {
   margin-top: 156px;
 }


### PR DESCRIPTION
### Overview

**Ticket:** 330699330
**fix:** change styles to prevent unexpected space on pages with welcome modal

### Screenshots before changes

![image](https://github.com/google/testrun/assets/25095840/d1ab34a7-37a3-4e52-b393-f283050f1e1b)

### Screenshots after changes

![image](https://github.com/google/testrun/assets/25095840/313c57b3-3d8c-47e2-9407-4e441171e7a4)


