### PR TITLE
331572594: (fix) [a11Y] GAR 1.13 The firmware field validation

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/progress-initiate-form/progress-initiate-form.component.html
+++ b/modules/ui/src/app/pages/testrun/components/progress-initiate-form/progress-initiate-form.component.html
@@ -37,8 +37,21 @@ limitations under the License.
       [class.hidden]="selectedDevice === null"
       appearance="outline">
       <mat-label>Firmware</mat-label>
-      <input formControlName="firmware" matInput #firmwareInput />
+      <input
+        class="firmware-input"
+        formControlName="firmware"
+        matInput
+        #firmwareInput />
       <mat-hint>Please enter device firmware</mat-hint>
+      <mat-error
+        *ngIf="firmware.hasError('invalid_format')"
+        role="alert"
+        aria-live="assertive">
+        <span
+          >Please, check. The firmware value must be a maximum of 64 characters.
+          Only letters, numbers, and accented letters are permitted.</span
+        >
+      </mat-error>
       <mat-error *ngIf="firmware.errors?.['required']">
         <span>Firmware is <strong>required</strong></span>
       </mat-error>

--- a/modules/ui/src/app/pages/testrun/components/progress-initiate-form/progress-initiate-form.component.spec.ts
+++ b/modules/ui/src/app/pages/testrun/components/progress-initiate-form/progress-initiate-form.component.spec.ts
@@ -163,6 +163,29 @@ describe('ProgressInitiateFormComponent', () => {
         ).toEqual(true);
       });
 
+      it('should have "invalid_format" error when field does not meet validation rules', () => {
+        [
+          'very long value very long value very long value very long value very long value very long value very long value',
+          '!as&@3$',
+        ].forEach(value => {
+          const firmware: HTMLInputElement = compiled.querySelector(
+            '.firmware-input'
+          ) as HTMLInputElement;
+          firmware.value = value;
+          firmware.dispatchEvent(new Event('input'));
+          component.firmware.markAsTouched();
+          fixture.detectChanges();
+
+          const firmwareError = compiled.querySelector('mat-error')?.innerHTML;
+          const error = component.firmware.hasError('invalid_format');
+
+          expect(error).toBeTruthy();
+          expect(firmwareError).toContain(
+            'The firmware value must be a maximum of 64 characters. Only letters, numbers, and accented letters are permitted.'
+          );
+        });
+      });
+
       describe('when selectedDevice is present and firmware is filled', () => {
         beforeEach(() => {
           component.firmware.setValue('firmware');


### PR DESCRIPTION
### Overview

Ticket: 331572594: 
fix: [a11Y] GAR 1.13 The firmware field validation - add validation message to the UI
tests: add unit tests

### Screenshots after changes

![image](https://github.com/google/testrun/assets/25095840/d6e4d003-650d-4de9-9ab8-b7ae022c0925)

![image](https://github.com/google/testrun/assets/25095840/813ef605-1ee2-4537-a15a-12027a12a899)

