### PR TITLE
Bug/tls requirements

### DIFF
--- a/modules/test/tls/python/requirements.txt
+++ b/modules/test/tls/python/requirements.txt
@@ -1,4 +1,5 @@
-cryptography
-pyOpenSSL
-pyshark
-requests
+cryptography==2.8
+pyOpenSSL==19.0.0
+lxml==5.1.0 # Requirement of pyshark but if upgraded automatically above 5.1 will cause a python crash
+pyshark==0.6
+requests==2.28.2


### PR DESCRIPTION
Pin tls requirements for tls module to prevent python crashing when updating wrong versions