### PR TITLE
Bug/docker network dns

### DIFF
--- a/cmd/prune
+++ b/cmd/prune
@@ -36,4 +36,6 @@ fi
 # Remove docker networks
 echo Removing docker networks
 sudo docker network rm endev0 > /dev/null
-sudo docker network rm tr-private-net > /dev/null
+# Private network not used, add cleanup
+# back in if/when implemented
+#sudo docker network rm tr-private-net > /dev/null

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -491,7 +491,7 @@ class NetworkOrchestrator:
         name=net_module.container_name,
         hostname=net_module.container_name,
         # Undetermined version of docker seems to have broken
-        # DNS configuration (/etc/resolv.conf)  Re-add when/if 
+        # DNS configuration (/etc/resolv.conf)  Re-add when/if
         # this network is utilized and DNS issue is resolved
         #network=PRIVATE_DOCKER_NET,
         privileged=True,

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -357,7 +357,9 @@ class NetworkOrchestrator:
     if 'CI' in os.environ:
       self._ci_post_network_create()
 
-    self._create_private_net()
+    # Private network not used, disable until
+    # a use case is determined
+    #self._create_private_net()
 
     # Listener may have already been created. Only create if not
     if self._listener is None:

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -479,6 +479,7 @@ class NetworkOrchestrator:
     network = 'host' if net_module.net_config.host else PRIVATE_DOCKER_NET
     LOGGER.debug(f"""Network: {network}, image name: {net_module.image_name},
                      container name: {net_module.container_name}""")
+
     try:
       client = docker.from_env()
       net_module.container = client.containers.run(
@@ -487,7 +488,10 @@ class NetworkOrchestrator:
         cap_add=['NET_ADMIN'],
         name=net_module.container_name,
         hostname=net_module.container_name,
-        network=PRIVATE_DOCKER_NET,
+        # Undetermined version of docker seems to have broken
+        # DNS configuration (/etc/resolv.conf)  Re-add when/if 
+        # this network is utilized and DNS issue is resolved
+        #network=PRIVATE_DOCKER_NET,
         privileged=True,
         detach=True,
         mounts=net_module.mounts,


### PR DESCRIPTION
An undetermined version in docker appears to have changed its DNS configurations when using the docker network option currently being used in the network modules for a private network.  This causes the gateway to lose proper DNS resolving capability for internet access for test devices.  Private network was never used beyond implementing it so this removes the private network from use and restores the DNS to the gateway network module.