### PR TITLE
Add a SYN/ACK filter to unencrypted TLS check

### DIFF
--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -549,11 +549,14 @@ class TLSUtil():
 
     non_tls_dst_ips = set()  # Store unique destination IPs
     for packet in packets:
-      # Check if an IP address is within the specified subnet.
-      dst_ip = ipaddress.ip_address(packet['_source']['layers']['ip.dst'][0])
-      if not dst_ip in subnet_with_mask:
-        non_tls_dst_ips.add(str(dst_ip))
-
+      # Check if packet contains TCP layer
+        if 'tcp' in packet['_source']['layers']:
+          tcp_flags = packet['_source']['layers']['tcp.flags']
+          if 'A' not in tcp_flags and 'S' not in tcp_flags:
+            # Packet is not ACK or SYN
+            dst_ip = ipaddress.ip_address(packet['_source']['layers']['ip.dst'][0])
+            if not dst_ip in subnet_with_mask:
+              non_tls_dst_ips.add(str(dst_ip))
     return non_tls_dst_ips
 
   # Check if the device has made any outbound connections that don't


### PR DESCRIPTION
Filter any SYN/ACK traffic during TLS client checks for unencrypted traffic.  These are used for both TLS and non-TLS but can't be used to determine which.  Also present in incomplete connections which could cause failures for connections to any external endpoint that is down or unexpected network issues.