### PR TITLE
Support certificate names with spaces in TLS test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ testing/unit/dns/output/
 testing/unit/nmap/output/
 testing/unit/ntp/output/
 testing/unit/tls/output/
+testing/unit/tls/tmp/
 testing/unit/report/output/
 
 *.deb

--- a/framework/python/src/common/util.py
+++ b/framework/python/src/common/util.py
@@ -28,7 +28,7 @@ def run_command(cmd, output=True):
   By default, returns the standard output and error output
   If the caller sets optional output parameter to False,
   will only return a boolean result indicating if it was
-  succesful in running the command.  Failure is indicated
+  successful in running the command.  Failure is indicated
   by any return code from the process other than zero."""
 
   success = False
@@ -73,10 +73,10 @@ def get_os_user():
     user = os.getlogin()
   except OSError:
     # Handle the OSError exception
-    LOGGER.error('An OS error occured whilst calling os.getlogin()')
+    LOGGER.error('An OS error occurred whilst calling os.getlogin()')
   except Exception: # pylint: disable=W0703
     # Catch any other unexpected exceptions
-    LOGGER.error('An unknown exception occured whilst calling os.getlogin()')
+    LOGGER.error('An unknown exception occurred whilst calling os.getlogin()')
   return user
 
 def get_user():

--- a/framework/python/src/common/util.py
+++ b/framework/python/src/common/util.py
@@ -43,8 +43,11 @@ def run_command(cmd, output=True):
       LOGGER.error('Error: ' + err_msg)
     else:
       success = True
+      LOGGER.debug('Command succeeded: ' + cmd)
     if output:
-      return stdout.strip().decode('utf-8'), stderr
+      out = stdout.strip().decode('utf-8')
+      LOGGER.debug('Command output: ' + out)
+      return out, stderr
     else:
       return success
 

--- a/modules/devices/faux-dev/python/src/util.py
+++ b/modules/devices/faux-dev/python/src/util.py
@@ -16,15 +16,15 @@
 import subprocess
 import shlex
 
-# Runs a process at the os level
-# By default, returns the standard output and error output
-# If the caller sets optional output parameter to False,
-# will only return a boolean result indicating if it was
-# succesful in running the command.  Failure is indicated
-# by any return code from the process other than zero.
-
 
 def run_command(cmd, logger, output=True):
+  """Runs a process at the os level
+  By default, returns the standard output and error output
+  If the caller sets optional output parameter to False,
+  will only return a boolean result indicating if it was
+  successful in running the command.  Failure is indicated
+  by any return code from the process other than zero."""
+
   success = False
   process = subprocess.Popen(shlex.split(cmd),
                              stdout=subprocess.PIPE,
@@ -37,8 +37,10 @@ def run_command(cmd, logger, output=True):
     logger.error('Error: ' + err_msg)
   else:
     success = True
-
+    logger.debug('Command succeeded: ' + cmd)
   if output:
-    return success, stdout.strip().decode('utf-8')
+    out = stdout.strip().decode('utf-8')
+    logger.debug('Command output: ' + out)
+    return success, out
   else:
     return success, None

--- a/modules/test/base/python/src/util.py
+++ b/modules/test/base/python/src/util.py
@@ -19,13 +19,14 @@ import logger
 
 LOGGER = logger.get_logger('util')
 
-# Runs a process at the os level
-# By default, returns the standard output and error output
-# If the caller sets optional output parameter to False,
-# will only return a boolean result indicating if it was
-# succesful in running the command.  Failure is indicated
-# by any return code from the process other than zero.
 def run_command(cmd, output=True):
+  """Runs a process at the os level
+  By default, returns the standard output and error output
+  If the caller sets optional output parameter to False,
+  will only return a boolean result indicating if it was
+  successful in running the command.  Failure is indicated
+  by any return code from the process other than zero."""
+
   success = False
   process = subprocess.Popen(shlex.split(cmd),
                              stdout=subprocess.PIPE,
@@ -37,7 +38,10 @@ def run_command(cmd, output=True):
     LOGGER.error('Error: ' + err_msg)
   else:
     success = True
+    LOGGER.debug('Command succeeded: ' + cmd)
   if output:
-    return stdout.strip().decode('utf-8'), stderr
+    out = stdout.strip().decode('utf-8')
+    LOGGER.debug('Command output: ' + out)
+    return out, stderr
   else:
     return success

--- a/modules/test/tls/bin/check_cert_chain_signature.sh
+++ b/modules/test/tls/bin/check_cert_chain_signature.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-INTERMEDIATE=$1
-DEVICE_CERT=$2
+INTERMEDIATE="$1"
+DEVICE_CERT="$2"
 
 echo "ROOT: $ROOT_CERT"
 echo "DEVICE_CERT: $DEVICE_CERT"
 
-response=$(openssl verify -untrusted $INTERMEDIATE $DEVICE_CERT)
+response=$(openssl verify -untrusted "$INTERMEDIATE" "$DEVICE_CERT")
 
 echo "$response"

--- a/modules/test/tls/bin/check_cert_signature.sh
+++ b/modules/test/tls/bin/check_cert_signature.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ROOT_CERT=$1
-DEVICE_CERT=$2
+ROOT_CERT="$1"
+DEVICE_CERT="$2"
 
 echo "ROOT: $ROOT_CERT"
 echo "DEVICE_CERT: $DEVICE_CERT"
 
-response=$(openssl verify -CAfile $ROOT_CERT $DEVICE_CERT)
+response=$(openssl verify -CAfile "$ROOT_CERT" "$DEVICE_CERT")
 
 echo "$response"

--- a/modules/test/tls/bin/get_ciphers.sh
+++ b/modules/test/tls/bin/get_ciphers.sh
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CAPTURE_FILE=$1
-DST_IP=$2
-DST_PORT=$3
+CAPTURE_FILE="$1"
+DST_IP="$2"
+DST_PORT="$3"
 
 TSHARK_FILTER="ssl.handshake.ciphersuites and ip.dst==$DST_IP and tcp.dstport==$DST_PORT"
-response=$(tshark -r $CAPTURE_FILE -Y "$TSHARK_FILTER" -Vx | grep 'Cipher Suite:' | awk '{$1=$1};1' | sed 's/Cipher Suite: //')
+response=$(tshark -r "$CAPTURE_FILE" -Y "$TSHARK_FILTER" -Vx | grep 'Cipher Suite:' | awk '{$1=$1};1' | sed 's/Cipher Suite: //')
 
 echo "$response"

--- a/modules/test/tls/bin/get_client_hello_packets.sh
+++ b/modules/test/tls/bin/get_client_hello_packets.sh
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CAPTURE_FILE=$1
-SRC_IP=$2
-TLS_VERSION=$3
+CAPTURE_FILE="$1"
+SRC_IP="$2"
+TLS_VERSION="$3"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 TSHARK_FILTER="ssl.handshake.type==1 and ip.src==$SRC_IP"
@@ -27,7 +27,7 @@ elif [ $TLS_VERSION == '1.3' ];then
   TSHARK_FILTER="$TSHARK_FILTER and (ssl.handshake.version==0x0304 or tls.handshake.extensions.supported_version==0x0304)"
 fi
 
-response=$(tshark -r $CAPTURE_FILE $TSHARK_OUTPUT $TSHARK_FILTER)
+response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
   	

--- a/modules/test/tls/bin/get_handshake_complete.sh
+++ b/modules/test/tls/bin/get_handshake_complete.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CAPTURE_FILE=$1
-SRC_IP=$2
-DST_IP=$3
-TLS_VERSION=$4
+CAPTURE_FILE="$1"
+SRC_IP="$2"
+DST_IP="$3"
+TLS_VERSION="$4"
 
 TSHARK_FILTER="ip.src==$SRC_IP and ip.dst==$DST_IP "
 
@@ -27,7 +27,7 @@ elif [ $TLS_VERSION == '1.2' ];then
 	TSHARK_FILTER=$TSHARK_FILTER "and ssl.handshake.type==2 and tls.handshake.extensions.supported_version==0x0304"
 fi
 
-response=$(tshark -r $CAPTURE_FILE $TSHARK_FILTER)
+response=$(tshark -r "$CAPTURE_FILE" $TSHARK_FILTER)
 
 echo "$response"
   	

--- a/modules/test/tls/bin/get_non_tls_client_connections.sh
+++ b/modules/test/tls/bin/get_non_tls_client_connections.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CAPTURE_FILE=$1
-SRC_IP=$2
+CAPTURE_FILE="$1"
+SRC_IP="$2"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 # Filter out TLS, DNS and NTP, ICMP (ping), braodcast and multicast packets
@@ -26,7 +26,7 @@ TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 # - ICMP (ping) requests are not encrypted so we also need to ignore these
 TSHARK_FILTER="ip.src == $SRC_IP and not tls and not dns and not ntp and not icmp and not(ip.dst == 224.0.0.0/4 or ip.dst == 255.255.255.255)"
 
-response=$(tshark -r $CAPTURE_FILE $TSHARK_OUTPUT $TSHARK_FILTER)
+response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
   	

--- a/modules/test/tls/bin/get_tls_client_connections.sh
+++ b/modules/test/tls/bin/get_tls_client_connections.sh
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CAPTURE_FILE=$1
-SRC_IP=$2
+CAPTURE_FILE="$1"
+SRC_IP="$2"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 TSHARK_FILTER="ip.src == $SRC_IP and tls"
 
-response=$(tshark -r $CAPTURE_FILE $TSHARK_OUTPUT $TSHARK_FILTER)
+response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
   	

--- a/modules/test/tls/bin/get_tls_packets.sh
+++ b/modules/test/tls/bin/get_tls_packets.sh
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 
-CAPTURE_FILE=$1
-SRC_IP=$2
-TLS_VERSION=$3
+CAPTURE_FILE="$1"
+SRC_IP="$2"
+TLS_VERSION="$3"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 # Handshakes will still report TLS version 1 even for TLS 1.2 connections
@@ -34,7 +34,7 @@ elif [ $TLS_VERSION == '1.3' ];then
 	TSHARK_FILTER="$TSHARK_FILTER and ssl.record.version==0x0304"
 fi
 
-response=$(tshark -r $CAPTURE_FILE $TSHARK_OUTPUT $TSHARK_FILTER)
+response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
   	

--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -188,9 +188,10 @@ class TLSUtil():
         # Create the file path
         root_cert_path = os.path.join(self._root_certs_dir, root_cert)
         LOGGER.info('Checking root cert: ' + str(root_cert_path))
-        args = f'{root_cert_path} {device_cert_path}'
+        args = f'"{root_cert_path}" "{device_cert_path}"'
         command = f'{bin_file} {args}'
         response = util.run_command(command)
+        LOGGER.debug(response)
         if f'{device_cert_path}: OK' in str(response):
           LOGGER.info('Device signed by cert:' + root_cert)
           return True, root_cert_path
@@ -257,9 +258,10 @@ class TLSUtil():
 
     # Use openssl script to validate the combined certificate
     # against the available trusted CA's
-    args = f'{intermediate_cert_path} {combined_cert_path}'
+    args = f'"{intermediate_cert_path}" "{combined_cert_path}"'
     command = f'{bin_file} {args}'
     response = util.run_command(command)
+    LOGGER.debug(response)
     return combined_cert_name + ': OK' in str(response)
 
   def get_ca_issuer(self, certificate):
@@ -407,9 +409,10 @@ class TLSUtil():
 
   def get_ciphers(self, capture_file, dst_ip, dst_port):
     bin_file = self._bin_dir + '/get_ciphers.sh'
-    args = f'{capture_file} {dst_ip} {dst_port}'
+    args = f'"{capture_file}" {dst_ip} {dst_port}'
     command = f'{bin_file} {args}'
     response = util.run_command(command)
+    LOGGER.debug(response)
     ciphers = response[0].split('\n')
     return ciphers
 
@@ -417,9 +420,10 @@ class TLSUtil():
     combined_results = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_client_hello_packets.sh'
-      args = f'{capture_file} {src_ip} {tls_version}'
+      args = f'"{capture_file}" {src_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
+      LOGGER.debug(response)
       packets = response[0].strip()
       if len(packets) > 0:
         # Parse each packet and append key-value pairs to combined_results
@@ -431,9 +435,10 @@ class TLSUtil():
     combined_results = ''
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_handshake_complete.sh'
-      args = f'{capture_file} {src_ip} {dst_ip} {tls_version}'
+      args = f'"{capture_file}" {src_ip} {dst_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
+      LOGGER.debug(response)
       if len(response) > 0:
         combined_results += response[0]
     return combined_results
@@ -443,9 +448,10 @@ class TLSUtil():
     combined_packets = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_non_tls_client_connections.sh'
-      args = f'{capture_file} {client_ip}'
+      args = f'"{capture_file}" {client_ip}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
+      LOGGER.debug(response)
       if len(response) > 0:
         packets = json.loads(response[0].strip())
         combined_packets.extend(packets)
@@ -456,7 +462,7 @@ class TLSUtil():
     combined_packets = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_tls_client_connections.sh'
-      args = f'{capture_file} {client_ip}'
+      args = f'"{capture_file}" {client_ip}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
       packets = json.loads(response[0].strip())
@@ -471,9 +477,10 @@ class TLSUtil():
     combined_results = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_tls_packets.sh'
-      args = f'{capture_file} {src_ip} {tls_version}'
+      args = f'"{capture_file}" {src_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
+      LOGGER.debug(response)
       packets = response[0].strip()
       # Parse each packet and append key-value pairs to combined_results
       result = self.parse_packets(json.loads(packets), capture_file)

--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -191,7 +191,6 @@ class TLSUtil():
         args = f'"{root_cert_path}" "{device_cert_path}"'
         command = f'{bin_file} {args}'
         response = util.run_command(command)
-        LOGGER.debug(response)
         if f'{device_cert_path}: OK' in str(response):
           LOGGER.info('Device signed by cert:' + root_cert)
           return True, root_cert_path
@@ -261,7 +260,6 @@ class TLSUtil():
     args = f'"{intermediate_cert_path}" "{combined_cert_path}"'
     command = f'{bin_file} {args}'
     response = util.run_command(command)
-    LOGGER.debug(response)
     return combined_cert_name + ': OK' in str(response)
 
   def get_ca_issuer(self, certificate):
@@ -412,7 +410,6 @@ class TLSUtil():
     args = f'"{capture_file}" {dst_ip} {dst_port}'
     command = f'{bin_file} {args}'
     response = util.run_command(command)
-    LOGGER.debug(response)
     ciphers = response[0].split('\n')
     return ciphers
 
@@ -423,7 +420,6 @@ class TLSUtil():
       args = f'"{capture_file}" {src_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
-      LOGGER.debug(response)
       packets = response[0].strip()
       if len(packets) > 0:
         # Parse each packet and append key-value pairs to combined_results
@@ -438,7 +434,6 @@ class TLSUtil():
       args = f'"{capture_file}" {src_ip} {dst_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
-      LOGGER.debug(response)
       if len(response) > 0:
         combined_results += response[0]
     return combined_results
@@ -451,7 +446,6 @@ class TLSUtil():
       args = f'"{capture_file}" {client_ip}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
-      LOGGER.debug(response)
       if len(response) > 0:
         packets = json.loads(response[0].strip())
         combined_packets.extend(packets)
@@ -480,7 +474,6 @@ class TLSUtil():
       args = f'"{capture_file}" {src_ip} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
-      LOGGER.debug(response)
       packets = response[0].strip()
       # Parse each packet and append key-value pairs to combined_results
       result = self.parse_packets(json.loads(packets), capture_file)


### PR DESCRIPTION
I noticed that the TLS test will fail if the Root CA file placed in `local/root_certs` has a space in its name.

The filename parameters are not being properly handled when passed from `tls_utils.py` to `check_cert_signature.sh`, thus the openssl call in the bash script returns `No such file or directory`.

As the `get_started.md` file doesn't make any restriction to the file name, it can be misleading not supporting spaces: 
> NOTE: Place your local CA certificate in local/root_certs (any name with a .crt extension) to perform TLS server tests

In this PR, I basically added double quotes to parameters that can be a file.
I've also included logs to the response of the bash commands for easier debugging.

I only touched the TLS module, the same issue can still happen in other modules