### PR TITLE
Change report limit default behavior

### DIFF
--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -89,7 +89,7 @@ class TestrunSession():
       'log_level': 'INFO',
       'startup_timeout': 60,
       'monitor_period': 30,
-      'max_device_reports': 5,
+      'max_device_reports': 0,
       'api_url': 'http://localhost',
       'api_port': 8000
     }

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -190,32 +190,33 @@ class TestOrchestrator:
     else:
       max_device_reports = self._session.get_max_device_reports()
 
-    completed_results_dir = os.path.join(
-        self._root_path,
-        LOCAL_DEVICE_REPORTS.replace("{device_folder}", device.device_folder))
+    if max_device_reports > 0:
+      completed_results_dir = os.path.join(
+          self._root_path,
+          LOCAL_DEVICE_REPORTS.replace("{device_folder}", device.device_folder))
 
-    completed_tests = os.listdir(completed_results_dir)
-    cur_test_count = len(completed_tests)
-    if cur_test_count > max_device_reports:
-      LOGGER.debug("Current device has more than max tests results allowed: " +
-                   str(cur_test_count) + ">" + str(max_device_reports))
+      completed_tests = os.listdir(completed_results_dir)
+      cur_test_count = len(completed_tests)
+      if cur_test_count > max_device_reports:
+        LOGGER.debug("Current device has more than max tests results allowed: " +
+                     str(cur_test_count) + ">" + str(max_device_reports))
 
-      # Find and delete the oldest test
-      oldest_test = self._find_oldest_test(completed_results_dir)
-      if oldest_test is not None:
-        LOGGER.debug("Oldest test found, removing: " + str(oldest_test[1]))
-        shutil.rmtree(oldest_test[1], ignore_errors=True)
+        # Find and delete the oldest test
+        oldest_test = self._find_oldest_test(completed_results_dir)
+        if oldest_test is not None:
+          LOGGER.debug("Oldest test found, removing: " + str(oldest_test[1]))
+          shutil.rmtree(oldest_test[1], ignore_errors=True)
 
-        # Remove oldest test from session
-        oldest_timestamp = oldest_test[0]
-        self.get_session().get_target_device().remove_report(oldest_timestamp)
+          # Remove oldest test from session
+          oldest_timestamp = oldest_test[0]
+          self.get_session().get_target_device().remove_report(oldest_timestamp)
 
-        # Confirm the delete was succesful
-        new_test_count = len(os.listdir(completed_results_dir))
-        if (new_test_count != cur_test_count
-            and new_test_count > max_device_reports):
-          # Continue cleaning up until we're under the max
-          self._cleanup_old_test_results(device)
+          # Confirm the delete was succesful
+          new_test_count = len(os.listdir(completed_results_dir))
+          if (new_test_count != cur_test_count
+              and new_test_count > max_device_reports):
+            # Continue cleaning up until we're under the max
+            self._cleanup_old_test_results(device)
 
   def _find_oldest_test(self, completed_tests_dir):
     oldest_timestamp = None

--- a/local/system.json.example
+++ b/local/system.json.example
@@ -6,5 +6,5 @@
   "log_level": "INFO",
   "startup_timeout": 60,
   "monitor_period": 300,
-  "max_device_reports": 5
+  "max_device_reports": 0
 }


### PR DESCRIPTION
Change default report limit behavior to keep all reports.  Setting max_device_reports property to default to zero keeps all reports.

Supersedes https://github.com/google/testrun/pull/409