### PR TITLE
Bug/test results too long

### DIFF
--- a/modules/test/base/python/src/test_module.py
+++ b/modules/test/base/python/src/test_module.py
@@ -146,6 +146,10 @@ class TestModule:
             test['description'] = result[1]
           else:
             test['description'] = 'No description was provided for this test'
+
+          # Check if details were provided
+          if len(result)>2:
+            test['details'] = result[2]
       else:
         test['result'] = 'Error'
         test['description'] = 'An error occured whilst running this test'

--- a/modules/test/protocol/python/src/protocol_module.py
+++ b/modules/test/protocol/python/src/protocol_module.py
@@ -80,7 +80,16 @@ class ProtocolModule(TestModule):
     LOGGER.info('Running protocol.valid_modbus')
     # Extract basic device connection information
     modbus = Modbus(log=LOGGER, device_ip=self._device_ipv4_addr, config=config)
-    return modbus.validate_device()
+    results = modbus.validate_device()
+    # Determine results and return proper messaging and details
+    description = ''
+    if results[0] is None:
+      description = 'No modbus connection could be made'
+    elif results[0]:
+      description = 'Valid modbus communication detected'
+    else:
+      description = 'Failed to confirm valid modbus communication'
+    return results[0], description,  results[1]
 
   def get_local_ip(self, interface_name):
     try:

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -234,8 +234,18 @@ class TLSModule(TestModule):
           self._device_ipv4_addr, tls_version='1.2')
       tls_1_3_results = self._tls_util.validate_tls_server(
           self._device_ipv4_addr, tls_version='1.3')
-      return self._tls_util.process_tls_server_results(tls_1_2_results,
+      results = self._tls_util.process_tls_server_results(tls_1_2_results,
                                                        tls_1_3_results)
+      # Determine results and return proper messaging and details
+      description = ''
+      if results[0] is None:
+        description = 'TLS 1.2 certificate could not be validated'
+      elif results[0]:
+        description = 'TLS 1.2 certificate is valid'
+      else:
+        description = 'TLS 1.2 certificate is invalid'
+      return results[0], description,results[1]
+
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
       return 'Error', 'Could not resolve device IP address'
@@ -245,8 +255,18 @@ class TLSModule(TestModule):
     self._resolve_device_ip()
     # If the ipv4 address wasn't resolved yet, try again
     if self._device_ipv4_addr is not None:
-      return self._tls_util.validate_tls_server(self._device_ipv4_addr,
+      results = self._tls_util.validate_tls_server(self._device_ipv4_addr,
                                                 tls_version='1.3')
+      # Determine results and return proper messaging and details
+      description = ''
+      if results[0] is None:
+        description = 'TLS 1.3 certificate could not be validated'
+      elif results[0]:
+        description = 'TLS 1.3 certificate is valid'
+      else:
+        description = 'TLS 1.3 certificate is invalid'
+      return results[0], description,results[1]
+
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
       return 'Error', 'Could not resolve device IP address'
@@ -256,7 +276,16 @@ class TLSModule(TestModule):
     self._resolve_device_ip()
     # If the ipv4 address wasn't resolved yet, try again
     if self._device_ipv4_addr is not None:
-      return self._validate_tls_client(self._device_ipv4_addr, '1.2')
+      results = self._validate_tls_client(self._device_ipv4_addr, '1.2')
+      # Determine results and return proper messaging and details
+      description = ''
+      if results[0] is None:
+        description = 'No outbound connections were found'
+      elif results[0]:
+        description = 'TLS 1.2 client connections valid'
+      else:
+        description = 'TLS 1.2 client connections invalid'
+      return results[0], description,  results[1]
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
       return 'Error', 'Could not resolve device IP address'
@@ -266,7 +295,16 @@ class TLSModule(TestModule):
     self._resolve_device_ip()
     # If the ipv4 address wasn't resolved yet, try again
     if self._device_ipv4_addr is not None:
-      return self._validate_tls_client(self._device_ipv4_addr, '1.3')
+      results = self._validate_tls_client(self._device_ipv4_addr, '1.3')
+      # Determine results and return proper messaging and details
+      description = ''
+      if results[0] is None:
+        description = 'No outbound connections were found'
+      elif results[0]:
+        description = 'TLS 1.3 client connections valid'
+      else:
+        description = 'TLS 1.3 client connections invalid'
+      return results[0], description,  results[1]
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
       return 'Error', 'Could not resolve device IP address'


### PR DESCRIPTION
- Add a third return result for tests to be stored in details
- Shorten TLS and Modbus result descriptions
- Move current long descriptions for TLS and Modbus to details in json report