### PR TITLE
Reconnecting the adapters causes disabling the settings selection

### DIFF
--- a/modules/ui/src/app/app.component.spec.ts
+++ b/modules/ui/src/app/app.component.spec.ts
@@ -287,14 +287,16 @@ describe('AppComponent', () => {
     });
   }));
 
-  it('should update interfaces', () => {
+  it('should update interfaces and config', () => {
     fixture.detectChanges();
 
     spyOn(component.settings, 'getSystemInterfaces');
+    spyOn(component.settings, 'getSystemConfig');
 
     component.openGeneralSettings(false);
 
     expect(component.settings.getSystemInterfaces).toHaveBeenCalled();
+    expect(component.settings.getSystemConfig).toHaveBeenCalled();
   });
 
   it('should call settingsDrawer open on openSetting', fakeAsync(() => {
@@ -650,6 +652,7 @@ class FakeGeneralSettingsComponent {
   @Output() closeSettingEvent = new EventEmitter<void>();
   @Output() reloadInterfacesEvent = new EventEmitter<void>();
   getSystemInterfaces = () => {};
+  getSystemConfig = () => {};
 }
 
 @Component({

--- a/modules/ui/src/app/app.component.ts
+++ b/modules/ui/src/app/app.component.ts
@@ -172,6 +172,7 @@ export class AppComponent implements OnInit {
   async openGeneralSettings(openSettingFromToggleBtn: boolean) {
     this.openedSettingFromToggleBtn = openSettingFromToggleBtn;
     this.settings.getSystemInterfaces();
+    this.settings.getSystemConfig();
     await this.settingsDrawer.open();
   }
 

--- a/modules/ui/src/app/pages/settings/components/settings-dropdown/settings-dropdown.component.ts
+++ b/modules/ui/src/app/pages/settings/components/settings-dropdown/settings-dropdown.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   inject,
   Input,
-  OnDestroy,
   OnInit,
 } from '@angular/core';
 import {
@@ -38,7 +37,7 @@ import { KeyValuePipe, NgForOf, NgIf } from '@angular/common';
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SettingsDropdownComponent implements OnInit, OnDestroy {
+export class SettingsDropdownComponent implements OnInit {
   @Input() key = '';
   @Input({ required: true }) controlName = '';
   @Input() groupLabel = '';
@@ -54,9 +53,6 @@ export class SettingsDropdownComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.parentFormGroup.addControl(this.controlName, new FormControl(''));
     this.parentFormGroup.addControl(this.controlName, new FormControl(''));
-  }
-  ngOnDestroy() {
-    this.parentFormGroup.removeControl(this.controlName);
   }
 
   get control(): FormControl {

--- a/modules/ui/src/app/pages/settings/general-settings.component.ts
+++ b/modules/ui/src/app/pages/settings/general-settings.component.ts
@@ -172,6 +172,10 @@ export class GeneralSettingsComponent implements OnInit, OnDestroy {
     this.hideLoading();
   }
 
+  getSystemConfig(): void {
+    this.settingsStore.getSystemConfig();
+  }
+
   private showLoading() {
     this.loaderService.setLoading(true);
   }


### PR DESCRIPTION
+ Do not remove form control on destroy as it causes error. No new control with the same name will be added on init 
https://github.com/angular/angular/blob/c1915f19c6f29b2421f1464e92e347d9bd86c07a/packages/forms/src/model/form_group.ts#L271

+ Call system/config on settings open

Video after changes
http://screencast/cast/NjYzOTYxNjUyOTUzMDg4MHw3ZDRkYjkwZS1lOA

Tests
![vxkpo8o86Wd6zGM](https://github.com/google/testrun/assets/22660354/b9170777-0f65-4d39-b9ff-fc903e419463)
