### PR TITLE
Fix style to allow screen reader to read label

### DIFF
--- a/modules/ui/src/styles.scss
+++ b/modules/ui/src/styles.scss
@@ -107,7 +107,7 @@ mat-hint {
   .mdc-button__label {
     position: relative;
     left: -999px;
-    display: none;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
It was broken when the scroll on mozilla was fixed. Styles changes, scroll is no appeared
![C73hSVynHLj9U6P](https://github.com/google/testrun/assets/22660354/159c9d89-88fe-4474-a08b-b0c13778031e)
