### PR TITLE
feature/test_module_temp_config_on_start

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -204,6 +204,7 @@ class Api:
         "A device with that MAC address could not be found")
 
     device.firmware = body_json["device"]["firmware"]
+    device.test_modules = body_json["device"]["test_modules"]
 
     # Check if config has been updated (device interface not default)
     if (self._test_run.get_session().get_device_interface()


### PR DESCRIPTION
Update device test module configuration from api start endpoint to allow temporary/one off runs for troubleshooting