### PR TITLE
The space is not allowed in the certificate name

### DIFF
--- a/modules/ui/src/app/mocks/certificate.mock.ts
+++ b/modules/ui/src/app/mocks/certificate.mock.ts
@@ -22,7 +22,7 @@ export const certificate = {
 } as Certificate;
 
 export const certificate_uploading = {
-  name: 'name.cert',
+  name: 'valid name ._-.cert',
   uploading: true,
 } as Certificate;
 
@@ -38,6 +38,6 @@ export const INVALID_FILE = {
 } as File;
 
 export const FILE = {
-  name: 'name.cert',
+  name: 'valid name ._-.cert',
   size: 3000,
 } as File;

--- a/modules/ui/src/app/pages/certificates/certificate.validator.ts
+++ b/modules/ui/src/app/pages/certificates/certificate.validator.ts
@@ -1,6 +1,6 @@
 const FILE_SIZE = 4;
 export const FILE_NAME_LENGTH = 24;
-const FILE_NAME_REGEXP = new RegExp('^[\\w.-]{1,24}$', 'u');
+const FILE_NAME_REGEXP = new RegExp('^[\\w .-]{1,24}$', 'u');
 const FILE_EXT_REGEXP = new RegExp('(\\.cert|\\.crt|\\.pem|\\.cer)$', 'i');
 
 export const getValidationErrors = (file: File): string[] => {


### PR DESCRIPTION
Adds space in certificate name regexp 

![5LmVNqLPBRYzZ8u](https://github.com/google/testrun/assets/22660354/49cbd768-15ce-48bf-9350-c6ce532da843)
