### PR TITLE
Change network mode on network modules to fix gateway routing

### DIFF
--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -538,6 +538,7 @@ class NetworkOrchestrator:
           # DNS configuration (/etc/resolv.conf)  Re-add when/if
           # this network is utilized and DNS issue is resolved
           #network=PRIVATE_DOCKER_NET,
+          network_mode="none",
           privileged=True,
           detach=True,
           mounts=net_module.mounts,


### PR DESCRIPTION
Default docker network mode results in bad routing for internet traffic to/from the gateway module.  Bug originated from removal of private network during network module start which prevented default docker networking configuration. This sets network mode to none which allows only specific interface and routing setup by Testrun to be in control of traffic.