### PR TITLE
Fix bad multiple ip report when no ip requested

### DIFF
--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -237,6 +237,9 @@ class ConnectionModule(TestModule):
     result = self._device_mac.upper() in mac_addresses
     LOGGER.info('DHCPREQUEST detected from device: ' + str(result))
 
+    if not result:
+      return result, 'Device did not request a DHCP address.'
+
     # Check the unique MAC addresses to see if they match the device
     for mac_address in mac_addresses:
       result &= self._device_mac.upper() == mac_address


### PR DESCRIPTION
If no DHCPREQUEST detected from device, single IP test would report as multiple IP's detected. Accounts for this state and reports proper messaging.