### PR TITLE
The risk profile name of removed risk profile can not be used for another risk profile

### DIFF
--- a/modules/ui/src/app/mocks/profile.mock.ts
+++ b/modules/ui/src/app/mocks/profile.mock.ts
@@ -54,6 +54,11 @@ export const PROFILE_MOCK_2: Profile = {
   questions: [],
 };
 
+export const PROFILE_MOCK_3: Profile = {
+  name: 'Third profile name',
+  questions: [],
+};
+
 export const PROFILE_FORM: ProfileFormat[] = [
   {
     question: 'Email',

--- a/modules/ui/src/app/pages/risk-assessment/profile-form/profile-form.component.spec.ts
+++ b/modules/ui/src/app/pages/risk-assessment/profile-form/profile-form.component.spec.ts
@@ -23,6 +23,7 @@ import {
   PROFILE_FORM,
   PROFILE_MOCK,
   PROFILE_MOCK_2,
+  PROFILE_MOCK_3,
   RENAME_PROFILE_MOCK,
 } from '../../../mocks/profile.mock';
 import { FormControlType, ProfileStatus } from '../../../model/profile';
@@ -40,7 +41,7 @@ describe('ProfileFormComponent', () => {
     fixture = TestBed.createComponent(ProfileFormComponent);
     component = fixture.componentInstance;
     component.profileFormat = PROFILE_FORM;
-    component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2];
+    component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2, PROFILE_MOCK_3];
     compiled = fixture.nativeElement as HTMLElement;
 
     fixture.detectChanges();
@@ -385,6 +386,34 @@ describe('ProfileFormComponent', () => {
         component.onSaveClick(ProfileStatus.VALID);
 
         expect(emitSpy).toHaveBeenCalledWith(RENAME_PROFILE_MOCK);
+      });
+
+      it('should not have an error when uses the name of removed profile', () => {
+        component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2, PROFILE_MOCK_3];
+        component.nameControl.setValue('Third profile name');
+
+        expect(
+          component.nameControl.hasError('has_same_profile_name')
+        ).toBeTrue();
+
+        component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2];
+        expect(
+          component.nameControl.hasError('has_same_profile_name')
+        ).toBeFalse();
+      });
+
+      it('should have an error when uses the name of added profile', () => {
+        component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2];
+        component.nameControl.setValue('Third profile name');
+
+        expect(
+          component.nameControl.hasError('has_same_profile_name')
+        ).toBeFalse();
+
+        component.profiles = [PROFILE_MOCK, PROFILE_MOCK_2, PROFILE_MOCK_3];
+        expect(
+          component.nameControl.hasError('has_same_profile_name')
+        ).toBeTrue();
       });
     });
 


### PR DESCRIPTION
Small refactoring; update validators on selected profile update and on profile list update
Tests
![A8DdA9XH7APLn4n](https://github.com/google/testrun/assets/22660354/bf51ddf8-471c-4297-a056-93a189ca5109)


Video after changes
http://screencast/cast/NjU3MTEzMTI2MjczMDI0MHw3YWQ3NDBmOS0wYg