### PR TITLE
The risk profile draft is shown in the dropdown on the Download  ZIP popup; 404 error on redirect

### DIFF
--- a/modules/ui/src/app/components/download-report-zip/download-report-zip.component.spec.ts
+++ b/modules/ui/src/app/components/download-report-zip/download-report-zip.component.spec.ts
@@ -90,6 +90,7 @@ describe('DownloadReportZipComponent', () => {
         tick();
 
         expect(testrunServiceMock.downloadZip).toHaveBeenCalled();
+        expect(router.url).not.toBe(Routes.RiskAssessment);
         openSpy.calls.reset();
       }));
 

--- a/modules/ui/src/app/components/download-report-zip/download-report-zip.component.ts
+++ b/modules/ui/src/app/components/download-report-zip/download-report-zip.component.ts
@@ -79,9 +79,7 @@ export class DownloadReportZipComponent
         }
         if (profile === null) {
           this.route.navigate([Routes.RiskAssessment]);
-        }
-
-        if (this.url != null) {
+        } else if (this.url != null) {
           this.testrunService.downloadZip(this.getZipLink(this.url), profile);
         }
       });

--- a/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.spec.ts
+++ b/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.spec.ts
@@ -2,7 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DownloadZipModalComponent } from './download-zip-modal.component';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { PROFILE_MOCK, PROFILE_MOCK_2 } from '../../mocks/profile.mock';
+import {
+  PROFILE_MOCK,
+  PROFILE_MOCK_2,
+  PROFILE_MOCK_3,
+} from '../../mocks/profile.mock';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestRunService } from '../../services/test-run.service';
@@ -41,7 +45,7 @@ describe('DownloadZipModalComponent', () => {
       TestBed.overrideProvider(MAT_DIALOG_DATA, {
         useValue: {
           hasProfiles: true,
-          profiles: [PROFILE_MOCK_2, PROFILE_MOCK],
+          profiles: [PROFILE_MOCK_2, PROFILE_MOCK, PROFILE_MOCK_3],
         },
       });
 
@@ -106,7 +110,7 @@ describe('DownloadZipModalComponent', () => {
       closeSpy.calls.reset();
     });
 
-    it('should have sorted profiles', async () => {
+    it('should have filtered and sorted profiles', async () => {
       expect(component.profiles).toEqual([PROFILE_MOCK, PROFILE_MOCK_2]);
     });
 

--- a/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.ts
+++ b/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.ts
@@ -6,7 +6,11 @@ import {
   MatDialogRef,
 } from '@angular/material/dialog';
 import { EscapableDialogComponent } from '../escapable-dialog/escapable-dialog.component';
-import { Profile, RiskResultClassName } from '../../model/profile';
+import {
+  Profile,
+  ProfileStatus,
+  RiskResultClassName,
+} from '../../model/profile';
 import { MatButtonModule } from '@angular/material/button';
 import { CommonModule, NgForOf, NgIf } from '@angular/common';
 import { MatFormField } from '@angular/material/form-field';
@@ -47,7 +51,9 @@ export class DownloadZipModalComponent extends EscapableDialogComponent {
   ) {
     super(dialogRef);
     if (data.hasProfiles) {
-      this.profiles = [...data.profiles] as Profile[];
+      this.profiles = data.profiles.filter(
+        profile => profile.status === ProfileStatus.VALID
+      );
       this.profiles.sort((a, b) =>
         a.name.toLowerCase().localeCompare(b.name.toLowerCase())
       );

--- a/modules/ui/src/app/mocks/profile.mock.ts
+++ b/modules/ui/src/app/mocks/profile.mock.ts
@@ -50,11 +50,13 @@ export const PROFILE_MOCK: Profile = {
 };
 
 export const PROFILE_MOCK_2: Profile = {
+  status: ProfileStatus.VALID,
   name: 'Second profile name',
   questions: [],
 };
 
 export const PROFILE_MOCK_3: Profile = {
+  status: ProfileStatus.DRAFT,
   name: 'Third profile name',
   questions: [],
 };


### PR DESCRIPTION
Show only valid profile in modal; fix condition to not download profile if redirect button clicked

Tests
![6W9Uw6qf3FJQCcG](https://github.com/google/testrun/assets/22660354/2a4859b5-f53a-41d7-afda-977781661d83)


Video after changes
http://screencast/cast/NTgxNjcwNDg1NTcwMzU1MnwxNjYwMmFmNy0wZA