### PR TITLE
bug/zip_file

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -540,9 +540,18 @@ class Api:
       return self._generate_msg(False, "Invalid JSON received")
 
   async def get_report(self, response: Response, device_name, timestamp):
+    device = self._session.get_device_by_name(device_name)
 
-    file_path = os.path.join(DEVICES_PATH, device_name, "reports", timestamp,
+    # 1.3 file path
+    file_path = os.path.join(DEVICES_PATH, device_name, "reports", timestamp,'test',
+          device.mac_addr.replace(':',''),
+          "report.pdf")
+    if not os.path.isfile(file_path):
+      # pre 1.3 file path
+      file_path = os.path.join(DEVICES_PATH, device_name, "reports", timestamp,
                              "report.pdf")
+        
+
     LOGGER.debug(f"Received get report request for {device_name} / {timestamp}")
     if os.path.isfile(file_path):
       return FileResponse(file_path)

--- a/framework/python/src/core/testrun.py
+++ b/framework/python/src/core/testrun.py
@@ -209,10 +209,20 @@ class Testrun:  # pylint: disable=too-few-public-methods
     LOGGER.info(f'Loading reports from {reports_folder}')
 
     for report_folder in os.listdir(reports_folder):
+      # 1.3 file path
       report_json_file_path = os.path.join(
         reports_folder,
         report_folder,
+        'test',
+        device.mac_addr.replace(':',''),
         'report.json')
+        
+      if not os.path.isfile(report_json_file_path):
+        # Revert to pre 1.3 file path
+        report_json_file_path = os.path.join(
+          reports_folder,
+          report_folder,
+          'report.json')
 
       # Check if the report.json file exists
       if not os.path.isfile(report_json_file_path):

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -242,8 +242,7 @@ class TestOrchestrator:
   def _timestamp_results(self, device):
 
     # Define the current device results directory
-    cur_results_dir = os.path.join(self._root_path, RUNTIME_TEST_DIR,
-                                   device.mac_addr.replace(":", ""))
+    cur_results_dir = os.path.join(self._root_path, RUNTIME_DIR)
 
     # Define the directory
     completed_results_dir = os.path.join(
@@ -273,9 +272,7 @@ class TestOrchestrator:
         timestamp)
 
       # Define where to save the zip file
-      zip_location = os.path.join(LOCAL_DEVICE_REPORTS.replace(
-        "{device_folder}", device.device_folder), timestamp
-      )
+      zip_location = os.path.join('/tmp/testrun',timestamp)
 
       # Include profile if specified
       if profile is not None:


### PR DESCRIPTION
- Move runtime contents unzipped into device report folder
- Create zip files in /tmp/testrun directory instead of in report folder
- Update API to handle both old and new file paths for report resolution