### PR TITLE
Support longer string answers in profile PDF

### DIFF
--- a/framework/python/src/common/risk_profile.py
+++ b/framework/python/src/common/risk_profile.py
@@ -378,13 +378,13 @@ class RiskProfile():
       if isinstance(question['answer'], str):
         content += question['answer']
 
-        if len(question['answer'] > 400):
+        if len(question['answer']) > 400:
           height += 160
-        elif len(question['answer'] > 300):
+        elif len(question['answer']) > 300:
           height += 140
-        elif len(question['answer'] > 200):
+        elif len(question['answer']) > 200:
           height += 120
-        elif len(question['answer'] > 100):
+        elif len(question['answer']) > 100:
           height += 70
         else:
           height += 53

--- a/framework/python/src/common/risk_profile.py
+++ b/framework/python/src/common/risk_profile.py
@@ -377,7 +377,17 @@ class RiskProfile():
       # String answers (one line)
       if isinstance(question['answer'], str):
         content += question['answer']
-        height += 53
+
+        if len(question['answer'] > 400):
+          height += 160
+        elif len(question['answer'] > 300):
+          height += 140
+        elif len(question['answer'] > 200):
+          height += 120
+        elif len(question['answer'] > 100):
+          height += 70
+        else:
+          height += 53
 
       # Select multiple answers
       elif isinstance(question['answer'], list):

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -515,7 +515,7 @@ class TestrunSession():
     with open(os.path.join(PROFILES_DIR, risk_profile.name + '.json'),
               'w',
               encoding='utf-8') as f:
-      f.write(risk_profile.to_json())
+      f.write(risk_profile.to_json(pretty=True))
 
     return risk_profile
 


### PR DESCRIPTION
Example PDF output with long answers: 

[profile.pdf](https://github.com/user-attachments/files/16101298/profile.pdf)

JSON file is also formatted correctly.
