### PR TITLE
Remove skipped result

### DIFF
--- a/modules/test/base/python/src/test_module.py
+++ b/modules/test/base/python/src/test_module.py
@@ -125,9 +125,9 @@ class TestModule:
           test['description'] = 'No description was provided for this test'
         else:
           # TODO: This is assuming that result is an array but haven't checked
-          # Skipped result
+          # Error result
           if result[0] is None:
-            test['result'] = 'Skipped'
+            test['result'] = 'Error'
             if len(result) > 1:
               test['description'] = result[1]
             else:


### PR DESCRIPTION
Remove the skipped result from the base test module. Skipped results should no longer exist and have now been replaced with Feature Not Detected or Error.