### PR TITLE
Prevent creating device with duplicate manufacturer and model

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -449,7 +449,16 @@ class Api:
         response.status_code = status.HTTP_400_BAD_REQUEST
         return self._generate_msg(False, "Invalid request received")
 
+      # Check if device with same MAC exists
       device = self._session.get_device(device_json.get(DEVICE_MAC_ADDR_KEY))
+
+      if device is None:
+
+        # Check if device with same manufacturer and model exists
+        device = self._session.get_device_by_make_and_model(
+          device_json.get(DEVICE_MANUFACTURER_KEY),
+          device_json.get(DEVICE_MODEL_KEY)
+        )
 
       if device is None:
 
@@ -468,7 +477,7 @@ class Api:
 
         response.status_code = status.HTTP_409_CONFLICT
         return self._generate_msg(
-            False, "A device with that " + "MAC address already exists")
+            False, "A device with that MAC address or name already exists")
 
       return device.to_config_json()
 

--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -452,7 +452,7 @@ class Api:
       # Check if device with same MAC exists
       device = self._session.get_device(device_json.get(DEVICE_MAC_ADDR_KEY))
 
-      if device is None:
+      if device is not None:
 
         response.status_code = status.HTTP_409_CONFLICT
         return self._generate_msg(

--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -454,11 +454,15 @@ class Api:
 
       if device is None:
 
-        # Check if device with same manufacturer and model exists
-        device = self._session.get_device_by_make_and_model(
-          device_json.get(DEVICE_MANUFACTURER_KEY),
-          device_json.get(DEVICE_MODEL_KEY)
-        )
+        response.status_code = status.HTTP_409_CONFLICT
+        return self._generate_msg(
+            False, "A device with that MAC address already exists")
+
+      # Check if device with same manufacturer and model exists
+      device = self._session.get_device_by_make_and_model(
+        device_json.get(DEVICE_MANUFACTURER_KEY),
+        device_json.get(DEVICE_MODEL_KEY)
+      )
 
       if device is None:
 
@@ -477,7 +481,7 @@ class Api:
 
         response.status_code = status.HTTP_409_CONFLICT
         return self._generate_msg(
-            False, "A device with that MAC address or name already exists")
+            False, "A device with that manufacturer and model already exists")
 
       return device.to_config_json()
 
@@ -552,14 +556,17 @@ class Api:
     device = self._session.get_device_by_name(device_name)
 
     # 1.3 file path
-    file_path = os.path.join(DEVICES_PATH, device_name, "reports", timestamp,'test',
-          device.mac_addr.replace(':',''),
+    file_path = os.path.join(
+      DEVICES_PATH,
+      device_name,
+      "reports",
+      timestamp,"test",
+          device.mac_addr.replace(":",""),
           "report.pdf")
     if not os.path.isfile(file_path):
       # pre 1.3 file path
       file_path = os.path.join(DEVICES_PATH, device_name, "reports", timestamp,
                              "report.pdf")
-        
 
     LOGGER.debug(f"Received get report request for {device_name} / {timestamp}")
     if os.path.isfile(file_path):

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -268,6 +268,11 @@ class TestrunSession():
         return device
     return None
 
+  def get_device_by_make_and_model(self, make, model):
+    for device in self._device_repository:
+      if device.manufacturer == make and device.model == model:
+        return device
+
   def get_device_repository(self):
     return self._device_repository
 


### PR DESCRIPTION
Users should not be able to have duplicate devices in their device repository. This includes checking for a duplicate MAC address, or duplicate manufacturer and model combination. This pull requests adds an additional check to ensure a device with the same manufacturer and model does not already exist - returning error 409 if one is found.