### PR TITLE
Cleanup old test devices from runtime

### DIFF
--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -186,11 +186,16 @@ class NetworkOrchestrator:
       # Ignore device if not registered
       return
 
+    # Cleanup any old test files
+    test_dir = os.path.join(RUNTIME_DIR, TEST_DIR)
+    device_tests = os.listdir(test_dir)
+    for device_test in device_tests:
+      device_test_path = os.path.join(RUNTIME_DIR,TEST_DIR,device_test)
+      if os.path.isdir(device_test_path):
+        shutil.rmtree(device_test_path, ignore_errors=True)
+
     device_runtime_dir = os.path.join(RUNTIME_DIR, TEST_DIR,
                                       mac_addr.replace(':', ''))
-
-    # Cleanup any old current test files
-    shutil.rmtree(device_runtime_dir, ignore_errors=True)
     os.makedirs(device_runtime_dir, exist_ok=True)
 
     util.run_command(f'chown -R {util.get_host_user()} {device_runtime_dir}')


### PR DESCRIPTION
When testing multiple devices within the same session, the runtime/test folder does not cleanup old devices, only the current one being tested on subsequent tests.  This causes multiple test reports from different devices to be stored incorrectly in the reports folder. PR cleans up all devices in the runtime/test folder on each new run.