### PR TITLE
2 callouts about system settings are shown on the first run

### DIFF
--- a/modules/ui/src/app/store/effects.spec.ts
+++ b/modules/ui/src/app/store/effects.spec.ts
@@ -268,6 +268,35 @@ describe('Effects', () => {
         done();
       });
     });
+
+    it('should call updateValidInterfaces and set all true if interface are empty and config is not set', done => {
+      actions$ = of(
+        actions.fetchInterfacesSuccess({
+          interfaces: {},
+        }),
+        actions.fetchSystemConfigSuccess({
+          systemConfig: {
+            network: {
+              device_intf: '',
+              internet_intf: '',
+            },
+          },
+        })
+      );
+
+      effects.checkInterfacesInConfig$.subscribe(action => {
+        expect(action).toEqual(
+          actions.updateValidInterfaces({
+            validInterfaces: {
+              hasSetInterfaces: true,
+              deviceValid: true,
+              internetValid: true,
+            },
+          })
+        );
+        done();
+      });
+    });
   });
 
   it('onFetchSystemStatus$ should call onFetchSystemStatusSuccess on success', done => {

--- a/modules/ui/src/app/store/effects.ts
+++ b/modules/ui/src/app/store/effects.ts
@@ -63,9 +63,11 @@ export class AppEffects {
             validInterfaces: {
               hasSetInterfaces: network != null,
               deviceValid:
-                !!network &&
-                !!network.device_intf &&
-                !!interfaces[network.device_intf],
+                (!!network &&
+                  !!network.device_intf &&
+                  !!interfaces[network.device_intf]) ||
+                (network?.device_intf == '' &&
+                  Object.keys(interfaces).length === 0),
               internetValid:
                 !!network &&
                 (network?.internet_intf == '' ||


### PR DESCRIPTION
Do not show settings callout if there are no interfaces and saved settings

tests
![6jCkba9TZg56JyP](https://github.com/google/testrun/assets/22660354/fd0c3fa2-807d-4c4c-b829-a3bd4de85882)

screenshot after changes
![7zwQwJ9UfjmZCFs](https://github.com/google/testrun/assets/22660354/8e9e11ba-97ce-452b-8cc2-da7998d45ea1)
