### PR TITLE
2 callouts about system settings are shown on the first run

### DIFF
--- a/modules/ui/src/app/model/setting.ts
+++ b/modules/ui/src/app/model/setting.ts
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 export interface SystemConfig {
-  network?: {
+  network: {
     device_intf?: string;
     internet_intf?: string;
-  };
+  } | null;
   log_level?: string;
   monitor_period?: number;
 }
 
 export interface InterfacesValidation {
-  hasSetInterfaces: boolean;
   deviceValid: boolean;
   internetValid: boolean;
 }

--- a/modules/ui/src/app/pages/settings/settings.component.spec.ts
+++ b/modules/ui/src/app/pages/settings/settings.component.spec.ts
@@ -90,7 +90,7 @@ describe('GeneralSettingsComponent', () => {
 
     component = fixture.componentInstance;
     component.viewModel$ = of({
-      systemConfig: {},
+      systemConfig: { network: {} },
       hasConnectionSettings: false,
       isSubmitting: false,
       isLessThanOneInterface: false,
@@ -255,7 +255,7 @@ describe('GeneralSettingsComponent', () => {
   describe('with no interfaces data', () => {
     beforeEach(() => {
       component.viewModel$ = of({
-        systemConfig: {},
+        systemConfig: { network: {} },
         hasConnectionSettings: false,
         isSubmitting: false,
         isLessThanOneInterface: false,
@@ -286,7 +286,7 @@ describe('GeneralSettingsComponent', () => {
   describe('with interfaces length less than one', () => {
     beforeEach(() => {
       component.viewModel$ = of({
-        systemConfig: {},
+        systemConfig: { network: {} },
         hasConnectionSettings: false,
         isSubmitting: false,
         isLessThanOneInterface: true,
@@ -325,7 +325,7 @@ describe('GeneralSettingsComponent', () => {
   describe('with interfaces length more then one', () => {
     beforeEach(() => {
       component.viewModel$ = of({
-        systemConfig: {},
+        systemConfig: { network: {} },
         hasConnectionSettings: false,
         isSubmitting: false,
         isLessThanOneInterface: false,

--- a/modules/ui/src/app/pages/settings/settings.store.spec.ts
+++ b/modules/ui/src/app/pages/settings/settings.store.spec.ts
@@ -27,10 +27,7 @@ import { AppState } from '../../store/state';
 import { skip, take } from 'rxjs';
 import { selectHasConnectionSettings } from '../../store/selectors';
 import { of } from 'rxjs/internal/observable/of';
-import {
-  fetchSystemConfigSuccess,
-  setHasConnectionSettings,
-} from '../../store/actions';
+import { fetchSystemConfigSuccess } from '../../store/actions';
 import { fetchInterfacesSuccess } from '../../store/actions';
 import { FormBuilder, FormControl } from '@angular/forms';
 import { FormKey, SystemConfig } from '../../model/setting';
@@ -131,7 +128,7 @@ describe('SettingsStore', () => {
     it('should select state', done => {
       settingsStore.viewModel$.pipe(take(1)).subscribe(store => {
         expect(store).toEqual({
-          systemConfig: {},
+          systemConfig: { network: {} },
           hasConnectionSettings: true,
           isSubmitting: false,
           isLessThanOneInterface: false,
@@ -149,46 +146,24 @@ describe('SettingsStore', () => {
   describe('effects', () => {
     describe('getSystemConfig', () => {
       beforeEach(() => {
-        mockService.getSystemConfig.and.returnValue(of({}));
+        mockService.getSystemConfig.and.returnValue(of({ network: {} }));
       });
 
       it('should dispatch action fetchSystemConfigSuccess', () => {
         settingsStore.getSystemConfig();
 
         expect(store.dispatch).toHaveBeenCalledWith(
-          fetchSystemConfigSuccess({ systemConfig: {} })
+          fetchSystemConfigSuccess({ systemConfig: { network: {} } })
         );
       });
 
       it('should update store', done => {
         settingsStore.viewModel$.pipe(skip(1), take(1)).subscribe(store => {
-          expect(store.systemConfig).toEqual({});
+          expect(store.systemConfig).toEqual({ network: {} });
           done();
         });
 
         settingsStore.getSystemConfig();
-      });
-
-      describe('should dispatch setHasConnectionSettings', () => {
-        it('with true if device_intf is present', () => {
-          mockService.getSystemConfig.and.returnValue(
-            of({ network: { device_intf: 'intf' } })
-          );
-          settingsStore.getSystemConfig();
-
-          expect(store.dispatch).toHaveBeenCalledWith(
-            setHasConnectionSettings({ hasConnectionSettings: true })
-          );
-        });
-
-        it('with false if device_intf is not present', () => {
-          mockService.getSystemConfig.and.returnValue(of({}));
-          settingsStore.getSystemConfig();
-
-          expect(store.dispatch).toHaveBeenCalledWith(
-            setHasConnectionSettings({ hasConnectionSettings: false })
-          );
-        });
       });
     });
 
@@ -221,32 +196,32 @@ describe('SettingsStore', () => {
 
     describe('updateSystemConfig', () => {
       beforeEach(() => {
-        mockService.createSystemConfig.and.returnValue(of({}));
+        mockService.createSystemConfig.and.returnValue(of({ network: {} }));
       });
 
       it('should dispatch action fetchSystemConfigSuccess', () => {
         settingsStore.updateSystemConfig(
           of({
             onSystemConfigUpdate: () => {},
-            config: {},
+            config: { network: {} },
           })
         );
 
         expect(store.dispatch).toHaveBeenCalledWith(
-          fetchSystemConfigSuccess({ systemConfig: {} })
+          fetchSystemConfigSuccess({ systemConfig: { network: {} } })
         );
       });
 
       it('should update store', done => {
         settingsStore.viewModel$.pipe(skip(1), take(1)).subscribe(store => {
-          expect(store.systemConfig).toEqual({});
+          expect(store.systemConfig).toEqual({ network: {} });
           done();
         });
 
         settingsStore.updateSystemConfig(
           of({
             onSystemConfigUpdate: () => {},
-            config: {},
+            config: { network: {} },
           })
         );
       });
@@ -254,7 +229,7 @@ describe('SettingsStore', () => {
       it('should call onSystemConfigUpdate', () => {
         const effectParams = {
           onSystemConfigUpdate: () => {},
-          config: {},
+          config: { network: {} },
         };
         const spyOnSystemConfigUpdate = spyOn(
           effectParams,

--- a/modules/ui/src/app/pages/settings/settings.store.ts
+++ b/modules/ui/src/app/pages/settings/settings.store.ts
@@ -143,13 +143,6 @@ export class SettingsStore extends ComponentStore<SettingsComponentState> {
               AppActions.fetchSystemConfigSuccess({ systemConfig })
             );
             this.setSystemConfig(systemConfig);
-            this.store.dispatch(
-              AppActions.setHasConnectionSettings({
-                hasConnectionSettings:
-                  systemConfig.network != null &&
-                  systemConfig.network.device_intf != '',
-              })
-            );
           })
         );
       })
@@ -291,7 +284,7 @@ export class SettingsStore extends ComponentStore<SettingsComponentState> {
     private store: Store<AppState>
   ) {
     super({
-      systemConfig: {},
+      systemConfig: { network: {} },
       hasConnectionSettings: false,
       isSubmitting: false,
       isLessThanOneInterface: false,

--- a/modules/ui/src/app/store/effects.spec.ts
+++ b/modules/ui/src/app/store/effects.spec.ts
@@ -66,8 +66,8 @@ describe('Effects', () => {
       'fetchProfiles',
     ]);
     testRunServiceMock.getSystemInterfaces.and.returnValue(of({}));
-    testRunServiceMock.getSystemConfig.and.returnValue(of({}));
-    testRunServiceMock.createSystemConfig.and.returnValue(of({}));
+    testRunServiceMock.getSystemConfig.and.returnValue(of({ network: {} }));
+    testRunServiceMock.createSystemConfig.and.returnValue(of({ network: {} }));
     testRunServiceMock.fetchSystemStatus.and.returnValue(
       of(MOCK_PROGRESS_DATA_IN_PROGRESS)
     );
@@ -157,9 +157,8 @@ describe('Effects', () => {
       actions$ = of(
         actions.updateValidInterfaces({
           validInterfaces: {
-            hasSetInterfaces: false,
-            deviceValid: false,
-            internetValid: false,
+            deviceValid: true,
+            internetValid: true,
           },
         })
       );
@@ -182,7 +181,6 @@ describe('Effects', () => {
       actions$ = of(
         actions.updateValidInterfaces({
           validInterfaces: {
-            hasSetInterfaces: true,
             deviceValid: false,
             internetValid: false,
           },
@@ -227,7 +225,6 @@ describe('Effects', () => {
         expect(action).toEqual(
           actions.updateValidInterfaces({
             validInterfaces: {
-              hasSetInterfaces: true,
               deviceValid: false,
               internetValid: true,
             },
@@ -259,7 +256,6 @@ describe('Effects', () => {
         expect(action).toEqual(
           actions.updateValidInterfaces({
             validInterfaces: {
-              hasSetInterfaces: true,
               deviceValid: true,
               internetValid: true,
             },
@@ -288,11 +284,73 @@ describe('Effects', () => {
         expect(action).toEqual(
           actions.updateValidInterfaces({
             validInterfaces: {
-              hasSetInterfaces: true,
               deviceValid: true,
               internetValid: true,
             },
           })
+        );
+        done();
+      });
+    });
+
+    it('should call updateValidInterfaces and set all true if interface are not empty and config is not set', done => {
+      actions$ = of(
+        actions.fetchInterfacesSuccess({
+          interfaces: {
+            enx00e04c020fa8: '00:e0:4c:02:0f:a8',
+            enx207bd26205e9: '20:7b:d2:62:05:e9',
+          },
+        }),
+        actions.fetchSystemConfigSuccess({
+          systemConfig: {
+            network: {
+              device_intf: '',
+              internet_intf: '',
+            },
+          },
+        })
+      );
+
+      effects.checkInterfacesInConfig$.subscribe(action => {
+        expect(action).toEqual(
+          actions.updateValidInterfaces({
+            validInterfaces: {
+              deviceValid: true,
+              internetValid: true,
+            },
+          })
+        );
+        done();
+      });
+    });
+  });
+
+  describe('onFetchSystemConfigSuccess$', () => {
+    it('should dispatch setHasConnectionSettings with true if device_intf is present', done => {
+      actions$ = of(
+        actions.fetchSystemConfigSuccess({
+          systemConfig: { network: { device_intf: 'intf' } },
+        })
+      );
+
+      effects.onFetchSystemConfigSuccess$.subscribe(action => {
+        expect(action).toEqual(
+          actions.setHasConnectionSettings({ hasConnectionSettings: true })
+        );
+        done();
+      });
+    });
+
+    it('should dispatch setHasConnectionSettings with false if device_intf is not present', done => {
+      actions$ = of(
+        actions.fetchSystemConfigSuccess({
+          systemConfig: { network: {} },
+        })
+      );
+
+      effects.onFetchSystemConfigSuccess$.subscribe(action => {
+        expect(action).toEqual(
+          actions.setHasConnectionSettings({ hasConnectionSettings: false })
         );
         done();
       });


### PR DESCRIPTION
Don't show error if config is empty; don't show settings callout when settings are not empty after saving

Tests
![3QcyBqZhtWK6suE](https://github.com/google/testrun/assets/22660354/e879f0a0-9e09-4cce-aa16-c7e7200c5816)

Video after changes
http://screencast/cast/NTY4OTE5NjgzOTY5ODQzMnwwOTRlYzFkMC1kZQ