### PR TITLE
Fix GAR bug with cert upload

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -792,7 +792,7 @@ class Api:
       response.status_code = status.HTTP_409_CONFLICT
       return self._generate_msg(False,
                                 "A certificate with that name already exists.")
-    except IOError:
+    except Exception:
       LOGGER.error("An error occurred whilst uploading the certificate")
 
     # Return error if something went wrong

--- a/framework/python/src/common/session.py
+++ b/framework/python/src/common/session.py
@@ -634,9 +634,6 @@ class TestrunSession():
 
       return cert_obj
 
-    except ValueError as e:
-      LOGGER.error(e)
-      raise
     except Exception as e:
       LOGGER.error('An error occured whilst parsing a certificate')
       LOGGER.debug(e)


### PR DESCRIPTION
When the user uploads a cert and an error occurs, the user is informed that a cert with the same name already exists. However, this is not the case, and instead the cert was not the correct format - raising an exception. The logic behind determining the error message for the user was incorrect. This PR aims to fix that by correcting error logic.