### PR TITLE
Remove output logging from OS level commands

### DIFF
--- a/framework/python/src/common/util.py
+++ b/framework/python/src/common/util.py
@@ -45,8 +45,6 @@ def run_command(cmd, output=True):
       success = True
     if output:
       out = stdout.strip().decode('utf-8')
-      if out is not None and len(out) != 0:
-        LOGGER.debug('Command output: ' + out)
       return out, stderr
     else:
       return success


### PR DESCRIPTION
Removes logging of output from the util class.  Even with debug option this spams the output. 