### PR TITLE
Add testrun.log to testing directory and fix bug with monitor

### DIFF
--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -288,6 +288,12 @@ class NetworkOrchestrator:
 
     while sniffer.running:
       time.sleep(1)
+
+      # Check Testrun hasn't been cancelled
+      if self._session.get_status() == 'Cancelled':
+        sniffer.stop()
+        return
+
       if not self._ip_ctrl.check_interface_status(
           self._session.get_device_interface()):
         sniffer.stop()

--- a/framework/python/src/test_orc/test_orchestrator.py
+++ b/framework/python/src/test_orc/test_orchestrator.py
@@ -256,6 +256,10 @@ class TestOrchestrator:
     shutil.copytree(cur_results_dir, completed_results_dir, dirs_exist_ok=True)
     util.run_command(f"chown -R {self._host_user} '{completed_results_dir}'")
 
+    # Copy Testrun log to testing directory
+    shutil.copy(os.path.join(self._root_path, "testrun.log"),
+                os.path.join(completed_results_dir, "testrun.log"))
+
     return completed_results_dir
 
   def zip_results(self,
@@ -272,7 +276,7 @@ class TestOrchestrator:
         timestamp)
 
       # Define temp directory to store files before zipping
-      results_dir = os.path.join(f'/tmp/testrun/{time.time()}')
+      results_dir = os.path.join(f"/tmp/testrun/{time.time()}")
 
       # Define where to save the zip file
       zip_location = os.path.join("/tmp/testrun",


### PR DESCRIPTION
Attaches the testrun.log file to the testing directory.

Fixes a bug where if you stop a Testrun during the monitor period, but start another Testrun immediately after, the Testrun is randomly cancelled. This is because the monitor period is still running in the background and detects the device interface being disconnected. This PR cancels the monitor sniffer when Testrun is cancelled.