### PR TITLE
353476778: (fix) GAR 2.11 change for prevent risk profile tiles overlap

### DIFF
--- a/modules/ui/src/app/pages/risk-assessment/profile-item/profile-item.component.scss
+++ b/modules/ui/src/app/pages/risk-assessment/profile-item/profile-item.component.scss
@@ -37,7 +37,7 @@ $profile-item-container-gap: 16px;
   padding: 12px 16px;
   border-bottom: 1px solid $lighter-grey;
   align-items: center;
-  height: 92px;
+  min-height: 92px;
 }
 
 .profile-item-icon-container {


### PR DESCRIPTION
### Overview

Ticket: 353476778
fix: GAR 2.11 change for prevent risk profile tiles overlap

### Screenshot before changes
https://screenshot.googleplex.com/BeFeQw93vuAVQeR

### Screenshot after changes
https://screenshot.googleplex.com/AHa85h9h88mtcXT