### PR TITLE
Fix individual test disabling when run from the UI

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -234,7 +234,16 @@ class Api:
           False, "Configured interfaces are not " +
           "ready for use. Ensure required interfaces " + "are connected.")
 
-    device.test_modules = body_json["device"]["test_modules"]
+    # UI doesn't send individual test configs so we need to
+    # merge these manually until the UI is updated to handle
+    # the full config file
+    for module_name, module_config in device.test_modules.items():
+      # Check if the module exists in UI test modules
+      if module_name in body_json["device"]["test_modules"]:
+        # Merge the enabled state
+        module_config["enabled"] = body_json["device"]["test_modules"][module_name]["enabled"]
+
+    LOGGER.info(f'Device config{device.test_modules}')
 
     LOGGER.info("Starting Testrun with device target " +
                 f"{device.manufacturer} {device.model} with " +

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -791,7 +791,6 @@ class NetworkOrchestrator:
     """Checks for changes in network adapters
     and sends a message to the frontend
     """
-    LOGGER.debug('checking network adatpers...')
     try:
       adapters = self._session.detect_network_adapters_change()
       if adapters:

--- a/modules/test/base/python/src/test_module.py
+++ b/modules/test/base/python/src/test_module.py
@@ -117,6 +117,7 @@ class TestModule:
           LOGGER.info(f'Test {test["name"]} not implemented. Skipping')
       else:
         LOGGER.debug(f'Test {test["name"]} is disabled')
+        result = 'Disabled', 'Test disabled, did not run'
 
       if result is not None:
         # Compliant or non-compliant as a boolean only


### PR DESCRIPTION
 When the UI sends the device test modules to the start command, it does not include the individual tests, only the test module so it overrides individual test configuration.  This PR merges these options properly when run from the UI.  It also handles the disabled state for the report.