### PR TITLE
Endpoint for a device profile questions

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -702,7 +702,7 @@ class Api:
       return questions
 
     except IndexError:
-      response.status_code = status.HTTP_400_BAD_REQUEST
+      response.status_code = status.HTTP_404_NOT_FOUND
       return self._generate_msg(
           False, f"Step {step} does not exist.")
 

--- a/resources/devices/device_profile.json
+++ b/resources/devices/device_profile.json
@@ -1,0 +1,353 @@
+[
+  {
+    "step": 1,
+    "questions": [
+      {
+        "id": 1,
+        "question": "What type of device is this?",
+        "validation": {
+          "required": true
+        },
+        "type": "select",
+        "options": [
+          {
+            "text": "Building Automation Gateway",
+            "risk": "High",
+            "id": 1
+          },
+          {
+            "text": "IoT Gateway",
+            "risk": "High",
+            "id": 2
+          },
+          {
+            "text": "Controller - AHU",
+            "risk": "High",
+            "id": 3
+          },
+          {
+            "text": "Controller - Boiler",
+            "risk": "High",
+            "id": 4
+          },
+          {
+            "text": "Controller - Chiller",
+            "risk": "High",
+            "id": 5
+          },
+          {
+            "text": "Controller - FCU",
+            "risk": "Limited",
+            "id": 6
+          },
+          {
+            "text": "Controller - Pump",
+            "risk": "Limited",
+            "id": 7
+          },
+          {
+            "text": "Controller - CRAC",
+            "risk": "High",
+            "id": 8
+          },
+          {
+            "text": "Controller - VAV",
+            "risk": "Limited",
+            "id": 9
+          },
+          {
+            "text": "Controller - VRF",
+            "risk": "Limited",
+            "id": 10
+          },
+          {
+            "text": "Controller - Multiple",
+            "risk": "High",
+            "id": 11
+          },
+          {
+            "text": "Controller - Other",
+            "risk": "High",
+            "id": 12
+          },
+          {
+            "text": "Controller - Lighting",
+            "risk": "Limited",
+            "id": 13
+          },
+          {
+            "text": "Controller - Blinds/Facades",
+            "risk": "High",
+            "id": 14
+          },
+          {
+            "text": "Controller - Lifts/Elevators",
+            "risk": "High",
+            "id": 15
+          },
+          {
+            "text": "Controller - UPS",
+            "risk": "High",
+            "id": 16
+          },
+          {
+            "text": "Sensor - Air Quality",
+            "risk": "Limited",
+            "id": 17
+          },
+          {
+            "text": "Sensor - Vibration",
+            "risk": "Limited",
+            "id": 18
+          },
+          {
+            "text": "Sensor - Humidity",
+            "risk": "Limited",
+            "id": 19
+          },
+          {
+            "text": "Sensor - Water",
+            "risk": "Limited",
+            "id": 20
+          },
+          {
+            "text": "Sensor - Occupancy",
+            "risk": "High",
+            "id": 21
+          },
+          {
+            "text": "Sensor - Volume",
+            "risk": "Limited",
+            "id": 22
+          },
+          {
+            "text": "Sensor - Weight",
+            "risk": "Limited",
+            "id": 23
+          },
+          {
+            "text": "Sensor - Weather",
+            "risk": "Limited",
+            "id": 24
+          },
+          {
+            "text": "Sensor - Steam",
+            "risk": "High",
+            "id": 25
+          },
+          {
+            "text": "Sensor - Air Flow",
+            "risk": "Limited",
+            "id": 26
+          },
+          {
+            "text": "Sensor - Lighting",
+            "risk": "Limited",
+            "id": 27
+          },
+          {
+            "text": "Sensor - Other",
+            "risk": "High",
+            "id": 28
+          },
+          {
+            "text": "Sensor - Air Quality",
+            "risk": "Limited",
+            "id": 29
+          },
+          {
+            "text": "Monitoring - Fire System",
+            "risk": "Limited",
+            "id": 30
+          },
+          {
+            "text": "Monitoring - Emergency Lighting",
+            "risk": "Limited",
+            "id": 31
+          },
+          {
+            "text": "Monitoring - Other",
+            "risk": "High",
+            "id": 32
+          },
+          {
+            "text": "Monitoring - UPS",
+            "risk": "Limited",
+            "id": 33
+          },
+          {
+            "text": "Meter - Water",
+            "risk": "Limited",
+            "id": 34
+          },
+          {
+            "text": "Meter - Gas",
+            "risk": "Limited",
+            "id": 35
+          },
+          {
+            "text": "Meter - Electricity",
+            "risk": "Limited",
+            "id": 36
+          },
+          {
+            "text": "Meter - Other",
+            "risk": "High",
+            "id": 37
+          },
+          {
+            "text": "Other",
+            "risk": "High",
+            "id": 38
+          },
+          {
+            "text": "Data - Storage",
+            "risk": "High",
+            "id": 39
+          },
+          {
+            "text": "Data - Processing",
+            "risk": "High",
+            "id": 40
+          },
+          {
+            "text": "Tablet",
+            "risk": "High",
+            "id": 41
+          }
+        ]
+      },
+      {
+        "id": 2,
+        "question": "Does your device process any sensitive information? ",
+        "validation": {
+          "required": true
+        },
+        "type": "select",
+        "options": [
+          {
+            "id": 1,
+            "text": "Yes",
+            "risk": "Limited"
+          },
+          {
+            "id": 2,
+            "text": "No",
+            "risk": "High"
+          },
+          {
+            "id": 3,
+            "text": "I don't know",
+            "risk": "High"
+          }
+        ]
+      },
+      {
+        "id": 3,
+        "question": "Please select the technology this device falls into",
+        "validation": {
+          "required": true
+        },
+        "type": "select",
+        "options": [
+          {
+            "id": 1,
+            "text": "Hardware - Access Control"
+          },
+          {
+            "id": 2,
+            "text": "Hardware - Air quality"
+          },
+          {
+            "id": 3,
+            "text": "Hardware - Asset location tracking"
+          },
+          {
+            "id": 4,
+            "text": "Hardware - Audio Visual"
+          },
+          {
+            "id": 5,
+            "text": "Hardware - Blinds/Facade"
+          },
+          {
+            "id": 6,
+            "text": "Hardware - Cameras"
+          },
+          {
+            "id": 7,
+            "text": "Hardware - Catering"
+          },
+          {
+            "id": 8,
+            "text": "Hardware - Data Ingestion/Managment"
+          },
+          {
+            "id": 9,
+            "text": "Hardware - EV Charging"
+          },
+          {
+            "id": 10,
+            "text": "Hardware - Fitness"
+          },
+          {
+            "id": 11,
+            "text": "Hardware - HVAC"
+          },
+          {
+            "id": 12,
+            "text": "Hardware - Irrigation"
+          },
+          {
+            "id": 13,
+            "text": "Hardware - Leak Detection"
+          },
+          {
+            "id": 14,
+            "text": "Hardware - Lifts/Elevators"
+          },
+          {
+            "id": 15,
+            "text": "Hardware - Lighting"
+          },
+          {
+            "id": 16,
+            "text": "Hardware - Metering"
+          },
+          {
+            "id": 17,
+            "text": "Hardware - Monitoring"
+          },
+          {
+            "id": 18,
+            "text": "Hardware - Occupancy"
+          },
+          {
+            "id": 19,
+            "text": "Hardware - System Integration"
+          },
+          {
+            "id": 20,
+            "text": "Hardware - Time Management"
+          },
+          {
+            "id": 21,
+            "text": "Hardware - UPS"
+          },
+          {
+            "id": 22,
+            "text": "Hardware - Waste Management"
+          },
+          {
+            "id": 23,
+            "text": "Building Automation"
+          },
+          {
+            "id": 24,
+            "text": "Other"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/resources/devices/device_profile.json
+++ b/resources/devices/device_profile.json
@@ -1,6 +1,8 @@
 [
   {
     "step": 1,
+    "title": "Select device type & technology",
+    "description": "Before your device can go through testing, tell us more about your device and its functionality. It is important that we fully understand your device before a thorough assessment can be made.",
     "questions": [
       {
         "id": 1,

--- a/testing/api/test_api.py
+++ b/testing/api/test_api.py
@@ -42,6 +42,8 @@ SYSTEM_CONFIG_PATH = "local/system.json"
 BASELINE_MAC_ADDR = "02:42:aa:00:01:01"
 ALL_MAC_ADDR = "02:42:aa:00:00:01"
 
+DEVICE_PROFILE_QUESTIONS = "resources/devices/device_profile.json"
+
 def pretty_print(dictionary: dict):
   """ Pretty print dictionary """
   print(json.dumps(dictionary, indent=4))
@@ -1444,3 +1446,26 @@ def test_delete_profile(testrun, reset_profiles, add_profile): # pylint: disable
   )
   # Check if profile was deleted
   assert deleted_profile is None
+
+
+def test_get_device_profile():
+  """ Test get device profile question"""
+  with open(DEVICE_PROFILE_QUESTIONS, "r", encoding="utf-8") as file:
+    questions = json.load(file)
+
+  # Checking the 400 error when a step does not exist.
+  r = requests.get(f"{API}/devices/format?step={len(questions) + 1}",
+                   timeout=5
+                   )
+  assert r.status_code == 400
+
+  r = requests.get(f"{API}/devices/format", timeout=5)
+  assert r.status_code == 200
+  r = requests.get(f"{API}/devices/format?step=1", timeout=5)
+  assert r.status_code == 200
+
+  # Check next_step is presented
+  if len(questions) == 1:
+    assert "next_step" not in r.json()
+  else:
+    assert "next_step" in r.json()

--- a/testing/api/test_api.py
+++ b/testing/api/test_api.py
@@ -1453,11 +1453,11 @@ def test_get_device_profile():
   with open(DEVICE_PROFILE_QUESTIONS, "r", encoding="utf-8") as file:
     questions = json.load(file)
 
-  # Checking the 400 error when a step does not exist.
+  # Checking the 404 error when a step does not exist.
   r = requests.get(f"{API}/devices/format?step={len(questions) + 1}",
                    timeout=5
                    )
-  assert r.status_code == 400
+  assert r.status_code == 404
 
   r = requests.get(f"{API}/devices/format", timeout=5)
   assert r.status_code == 200


### PR DESCRIPTION
I refactored the code so that a single endpoint will be used for all questions and answers. The questions are divided into steps, and if there is a subsequent step, a link to the next step will be included in the response. Each question and each answer has been assigned an ID. We discussed this solution with the team and concluded that it would be more convenient this way. Of course, at the moment, there is no need for such a structure, but it is implemented with the addition of new questions in mind.