### PR TITLE
367673910: (fix) prevent download PDF report button focused twice on completed testing modal

### DIFF
--- a/modules/ui/src/app/components/download-report/download-report.component.html
+++ b/modules/ui/src/app/components/download-report/download-report.component.html
@@ -18,6 +18,7 @@ limitations under the License.
     class="download-report-link {{ getClass(data) }}"
     [download]="getReportTitle(data)"
     [href]="href"
+    [tabIndex]="tabindex"
     target="_blank"
     [matTooltip]="title">
     <ng-content></ng-content>

--- a/modules/ui/src/app/components/download-report/download-report.component.ts
+++ b/modules/ui/src/app/components/download-report/download-report.component.ts
@@ -32,6 +32,7 @@ export class DownloadReportComponent extends ReportActionComponent {
   @Input() href: string | undefined;
   @Input() class!: string;
   @Input() title!: string;
+  @Input() tabindex = 0;
 
   getReportTitle(data: TestrunStatus) {
     return `${data.device.manufacturer} ${data.device.model} ${

--- a/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.html
+++ b/modules/ui/src/app/components/download-zip-modal/download-zip-modal.component.html
@@ -117,6 +117,7 @@ limitations under the License.
     <app-download-report
       *ngIf="data.testrunStatus"
       [data]="data.testrunStatus"
+      [tabindex]="-1"
       [href]="data.testrunStatus.report">
       <button
         (click)="cancel(undefined)"


### PR DESCRIPTION
### Overview

Ticket: 367673910
fix: prevent download PDF report button focused twice on completed testing modal

### Video before changes
https://screencast.googleplex.com/cast/NjU2NzkwODc5NTc0NDI1NnwyODBjZGUzNS01ZQ

### Video after changes
https://screencast.googleplex.com/cast/NTI4NjE2MjY0NTEyMzA3Mnw1NGJhNTc2YS03OQ