### PR TITLE
The confirmation dialogto save changes  appears for the Risk profile without changes made. 

### DIFF
--- a/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.spec.ts
+++ b/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.spec.ts
@@ -296,7 +296,7 @@ describe('RiskAssessmentComponent', () => {
         }));
 
         it('should call store saveProfile', fakeAsync(() => {
-          spyOn(component.dialog, 'open').and.returnValue({
+          const openSpy = spyOn(component.dialog, 'open').and.returnValue({
             afterClosed: () => of(true),
           } as MatDialogRef<typeof SimpleDialogComponent>);
 
@@ -308,6 +308,19 @@ describe('RiskAssessmentComponent', () => {
           // @ts-expect-error config is in object
           expect(args[0].profile).toEqual(NEW_PROFILE_MOCK);
           expect(mockRiskAssessmentStore.saveProfile).toHaveBeenCalled();
+          openSpy.calls.reset();
+        }));
+
+        it('should call store saveProfile and should not open save draft profile modal when profile does not have changes', fakeAsync(() => {
+          const openSpy = spyOn(component.dialog, 'open').and.returnValue({
+            afterClosed: () => of(true),
+          } as MatDialogRef<typeof SimpleDialogComponent>);
+
+          component.saveProfileClicked(PROFILE_MOCK, PROFILE_MOCK);
+
+          expect(openSpy).not.toHaveBeenCalled();
+          expect(mockRiskAssessmentStore.saveProfile).toHaveBeenCalled();
+          openSpy.calls.reset();
         }));
 
         it('should close the form', fakeAsync(() => {

--- a/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.ts
+++ b/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.ts
@@ -119,7 +119,7 @@ export class RiskAssessmentComponent implements OnInit, OnDestroy {
   }
 
   saveProfileClicked(profile: Profile, selectedProfile: Profile | null): void {
-    if (!selectedProfile) {
+    if (!selectedProfile || this.compareProfiles(profile, selectedProfile)) {
       this.saveProfile(profile, this.store.setFocusOnCreateButton);
     } else {
       this.openSaveDialog(
@@ -133,6 +133,50 @@ export class RiskAssessmentComponent implements OnInit, OnDestroy {
           }
         });
     }
+  }
+
+  private compareProfiles(profile1: Profile, profile2: Profile) {
+    if (profile1.name !== profile2.name) {
+      return false;
+    }
+    if (
+      profile1.rename === profile1.name &&
+      profile1.rename !== profile2.name
+    ) {
+      return false;
+    }
+    if (profile1.status !== profile2.status) {
+      return false;
+    }
+
+    for (const question of profile1.questions) {
+      const answer1 = question.answer;
+      const answer2 = profile2.questions?.find(
+        question2 => question2.question === question.question
+      )?.answer;
+      if (answer1 !== undefined && answer2 !== undefined) {
+        if (typeof question.answer === 'string') {
+          if (answer1 !== answer2) {
+            return false;
+          }
+        } else {
+          //the type of answer is array
+          if (answer1?.length !== answer2?.length) {
+            return false;
+          }
+          if (
+            (answer1 as number[]).some(
+              answer => !(answer2 as number[]).includes(answer)
+            )
+          )
+            return false;
+        }
+      } else {
+        return !!answer1 == !!answer2;
+      }
+    }
+
+    return true;
   }
 
   discard(selectedProfile: Profile | null) {


### PR DESCRIPTION
Do not show "Save changes" dialog when there is no changes in profile

Tests
![3ppqStjDzezxqGX](https://github.com/user-attachments/assets/21c9ed1a-043b-400b-b4ae-92521cc89db2)

Video after changes
http://screencast/cast/NjU4MzkwMDYzNjcwODg2NHwyOTE0NzgxNS1mYg