### PR TITLE
Fix baseline tests

### DIFF
--- a/modules/network/base/base.Dockerfile
+++ b/modules/network/base/base.Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Image name: testrun/base
-FROM ubuntu@sha256:e6173d4dc55e76b87c4af8db8821b1feae4146dd47341e4d431118c7dd060a74
+FROM ubuntu@sha256:77d57fd89366f7d16615794a5b53e124d742404e20f035c22032233f1826bd6a
 
 RUN apt-get update
 
@@ -30,8 +30,9 @@ COPY $COMMON_DIR/ /testrun/python/src/common
 # Setup the base python requirements
 COPY $MODULE_DIR/python /testrun/python
 
-# Install all python requirements for the module
-RUN pip3 install -r /testrun/python/requirements.txt
+# Install all python requirements for the module 
+# --break-system-packages flag used to bypass PEP668
+RUN pip3 install --break-system-packages -r /testrun/python/requirements.txt
 
 # Add the bin files
 COPY $MODULE_DIR/bin /testrun/bin

--- a/modules/network/radius/radius.Dockerfile
+++ b/modules/network/radius/radius.Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get update && apt-get install -y openssl freeradius git
 RUN git clone --branch 0.0.25 https://github.com/faucetsdn/chewie
 
 # Install chewie as Python module
-RUN pip3 install chewie/
+# --break-system-packages flag used to bypass PEP668
+RUN pip3 install --break-system-packages chewie/
 
 EXPOSE 1812/udp
 EXPOSE 1813/udp
@@ -40,4 +41,5 @@ COPY $MODULE_DIR/bin /testrun/bin
 COPY $MODULE_DIR/python /testrun/python
 
 # Install all python requirements for the module
-RUN pip3 install -r /testrun/python/requirements.txt
+# --break-system-packages flag used to bypass PEP668
+RUN pip3 install --break-system-packages -r /testrun/python/requirements.txt

--- a/testing/baseline/test_baseline
+++ b/testing/baseline/test_baseline
@@ -22,8 +22,6 @@ ifconfig
 sudo apt-get update
 sudo apt-get install openvswitch-common openvswitch-switch tcpdump jq moreutils coreutils isc-dhcp-client
 
-pip3 install pytest==7.4.4
-
 # Setup device network
 sudo ip link add dev endev0a type veth peer name endev0b
 sudo ip link set dev endev0a up
@@ -74,6 +72,11 @@ echo "Done baseline test"
 
 more $TESTRUN_OUT
 
-pytest testing/baseline/test_baseline.py
+# Needs to be sudo because this invokes bin/testrun 
+sudo venv/bin/python3 -m pytest -v testing/baseline/test_baseline.py
+
+# Clean the device network
+sudo ip link del dev endev0a
+sudo docker network rm endev0
 
 exit $?

--- a/testing/docker/ci_baseline/Dockerfile
+++ b/testing/docker/ci_baseline/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu@sha256:e6173d4dc55e76b87c4af8db8821b1feae4146dd47341e4d431118c7dd060a74
+FROM ubuntu@sha256:77d57fd89366f7d16615794a5b53e124d742404e20f035c22032233f1826bd6a
 
 # Update and get all additional requirements not contained in the base image 
 RUN apt-get update && apt-get -y upgrade


### PR DESCRIPTION
- Updated the Ubuntu image for baseline Docker file 
- added --break-system-packages flag to bypass PEP668 for the new Ubuntu image.
- updated test_baseline to run tests inside venv
- updated test_baseline to clean the device network after running all the tests