### PR TITLE
The focus is not returned to the previous element after closing the snackbar about new port availability

### DIFF
--- a/modules/ui/src/app/services/notification.service.ts
+++ b/modules/ui/src/app/services/notification.service.ts
@@ -53,6 +53,7 @@ export class NotificationService {
     timeout = TIMEOUT_MS,
     container?: Document | Element | null
   ) {
+    const previousActiveElement = document.activeElement;
     const panelClasses = ['test-run-notification'];
     if (panelClass) {
       panelClasses.push(panelClass);
@@ -72,9 +73,13 @@ export class NotificationService {
     this.snackBarRef
       .afterDismissed()
       .pipe(take(1))
-      .subscribe(() =>
-        this.focusManagerService.focusFirstElementInContainer(container)
-      );
+      .subscribe(() => {
+        if (previousActiveElement) {
+          (previousActiveElement as HTMLElement).focus();
+        } else {
+          this.focusManagerService.focusFirstElementInContainer(container);
+        }
+      });
   }
   dismiss() {
     this.snackBar.dismiss();


### PR DESCRIPTION
Return focus on previous active element

Video after changes
http://screencast/cast/NDYyOTIzODEzNjE3NjY0MHxmYTYyNWIxNC03MA