### PR TITLE
371177676: (fix) set focus to the initial device if cancel on edit device

### DIFF
--- a/modules/ui/src/app/pages/devices/devices.component.spec.ts
+++ b/modules/ui/src/app/pages/devices/devices.component.spec.ts
@@ -241,7 +241,15 @@ describe('DevicesComponent', () => {
         beforeClosed: () => of(null),
       } as MatDialogRef<typeof SimpleDialogComponent>);
 
-      component.openCloseDialog([device], MOCK_TEST_MODULES, device);
+      component.openCloseDialog(
+        [device],
+        MOCK_TEST_MODULES,
+        device,
+        undefined,
+        false,
+        0,
+        0
+      );
 
       expect(openDeviceDialogSpy).toHaveBeenCalledWith(
         [device],
@@ -249,6 +257,7 @@ describe('DevicesComponent', () => {
         device,
         undefined,
         false,
+        0,
         0
       );
     });

--- a/modules/ui/src/app/pages/devices/devices.component.ts
+++ b/modules/ui/src/app/pages/devices/devices.component.ts
@@ -235,7 +235,8 @@ export class DevicesComponent
           initialDevice,
           device,
           isEditDevice,
-          index
+          index,
+          deviceIndex
         );
       } else if (deviceIndex !== undefined) {
         this.focusSelectedButton(deviceIndex);


### PR DESCRIPTION
### Overview

Ticket: 371177676
fix: set focus to the initial device if cancel on edit device

### Video before changes
https://screencast.googleplex.com/cast/NDY2MTUxODA4Njk2MzIwMHwyYmRmNTBhMy1kZg

### Video after changes
https://screencast.googleplex.com/cast/NjE1MjgzNTY5MDM5NzY5NnwyMGNhODNkNS1jZQ