### PR TITLE
372768360: (feat) [Settings] only device port is enabled in no internet mode

### DIFF
--- a/modules/ui/src/app/app.store.ts
+++ b/modules/ui/src/app/app.store.ts
@@ -308,14 +308,14 @@ export class AppStore extends ComponentStore<AppComponentState> {
   checkInterfacesInConfig = this.effect(() => {
     return combineLatest([this.interfaces$, this.systemConfig$]).pipe(
       filter(([, { network }]) => network !== null),
-      tap(([interfaces, { network }]) => {
+      tap(([interfaces, { network, single_intf }]) => {
         const deviceValid =
           network?.device_intf == '' ||
           (!!network?.device_intf && !!interfaces[network.device_intf]);
-        const internetValid =
-          network?.internet_intf == '' ||
-          (!!network?.internet_intf && !!interfaces[network.internet_intf]);
-
+        const internetValid = single_intf
+          ? true
+          : network?.internet_intf == '' ||
+            (!!network?.internet_intf && !!interfaces[network.internet_intf]);
         this.updateSettingMissedError({
           isSettingMissed: !deviceValid || !internetValid,
           devicePortMissed: !deviceValid,

--- a/modules/ui/src/app/mocks/settings.mock.ts
+++ b/modules/ui/src/app/mocks/settings.mock.ts
@@ -33,16 +33,21 @@ export const MOCK_SYSTEM_CONFIG_WITH_DATA: SystemConfig = {
   monitor_period: 600,
 };
 
+export const MOCK_SYSTEM_CONFIG_WITH_SINGLE_PORT: SystemConfig = {
+  network: {
+    device_intf: 'mockDeviceKey',
+    internet_intf: '',
+  },
+  log_level: 'DEBUG',
+  monitor_period: 600,
+  single_intf: true,
+};
+
 export const MOCK_INTERFACES: SystemInterfaces = {
   mockDeviceKey: 'mockDeviceValue',
   mockInternetKey: 'mockInternetValue',
 };
 
-export const MOCK_INTERNET_OPTIONS: SystemInterfaces = {
-  '': 'Not specified',
-  mockDeviceKey: 'mockDeviceValue',
-  mockInternetKey: 'mockInternetValue',
-};
 export const MOCK_DEVICE_VALUE: SystemInterfaces = {
   key: 'mockDeviceKey',
   value: 'mockDeviceValue',

--- a/modules/ui/src/app/pages/settings/components/settings-dropdown/settings-dropdown.component.scss
+++ b/modules/ui/src/app/pages/settings/components/settings-dropdown/settings-dropdown.component.scss
@@ -48,6 +48,11 @@
 
 .setting-field {
   width: 100%;
+
+  &.mat-form-field-disabled {
+    opacity: 0.6;
+  }
+
   ::ng-deep .mat-mdc-form-field-infix {
     min-height: 76px;
     display: flex;

--- a/modules/ui/src/app/pages/settings/settings.component.html
+++ b/modules/ui/src/app/pages/settings/settings.component.html
@@ -36,7 +36,10 @@ limitations under the License.
         *ngIf="(vm.interfaces | keyvalue).length > 0; else warning_message">
         <app-callout
           [type]="CalloutType.Warning"
-          *ngIf="(vm.interfaces | keyvalue).length === 1"
+          *ngIf="
+            (vm.interfaces | keyvalue).length === 1 &&
+            !isInternetControlDisabled
+          "
           class="two-ports-message">
           Warning! Testrun requires two ports to operate correctly.
         </app-callout>

--- a/modules/ui/src/app/pages/settings/settings.component.spec.ts
+++ b/modules/ui/src/app/pages/settings/settings.component.spec.ts
@@ -33,7 +33,6 @@ import { LoaderService } from '../../services/loader.service';
 import { SettingsStore } from './settings.store';
 import {
   MOCK_INTERFACES,
-  MOCK_INTERNET_OPTIONS,
   MOCK_SYSTEM_CONFIG_WITH_DATA,
 } from '../../mocks/settings.mock';
 import { SettingsDropdownComponent } from './components/settings-dropdown/settings-dropdown.component';
@@ -331,7 +330,7 @@ describe('GeneralSettingsComponent', () => {
         isLessThanOneInterface: false,
         interfaces: MOCK_INTERFACES,
         deviceOptions: MOCK_INTERFACES,
-        internetOptions: MOCK_INTERNET_OPTIONS,
+        internetOptions: MOCK_INTERFACES,
         logLevelOptions: {},
         monitoringPeriodOptions: {},
       });

--- a/modules/ui/src/app/pages/settings/settings.component.ts
+++ b/modules/ui/src/app/pages/settings/settings.component.ts
@@ -83,7 +83,14 @@ export class SettingsComponent implements OnInit, OnDestroy {
   }
 
   get isFormValues(): boolean {
-    return this.internetControl?.value.value && this.deviceControl?.value.value;
+    return (
+      this.deviceControl?.value.value &&
+      (this.isInternetControlDisabled || this.internetControl?.value.value)
+    );
+  }
+
+  get isInternetControlDisabled(): boolean {
+    return this.internetControl?.disabled;
   }
 
   get isFormError(): boolean {
@@ -102,7 +109,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     this.createSettingForm();
     this.cleanFormErrorMessage();
     this.settingsStore.getInterfaces();
-    this.settingsStore.getSystemConfig();
+    this.getSystemConfig();
     this.setDefaultFormValues();
   }
 
@@ -112,7 +119,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     }
     this.showLoading();
     this.getSystemInterfaces();
-    this.settingsStore.getSystemConfig();
+    this.getSystemConfig();
     this.setDefaultFormValues();
   }
   closeSetting(message: string): void {
@@ -177,7 +184,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
     const data: SystemConfig = {
       network: {
         device_intf: device_intf.key,
-        internet_intf: internet_intf.key,
+        internet_intf: this.isInternetControlDisabled ? '' : internet_intf.key,
       },
       log_level: log_level.key,
       monitor_period: Number(monitor_period.key),

--- a/modules/ui/src/app/pages/settings/settings.store.spec.ts
+++ b/modules/ui/src/app/pages/settings/settings.store.spec.ts
@@ -13,12 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  DEFAULT_INTERNET_OPTION,
-  LOG_LEVELS,
-  MONITORING_PERIOD,
-  SettingsStore,
-} from './settings.store';
+import { LOG_LEVELS, MONITORING_PERIOD, SettingsStore } from './settings.store';
 import { TestRunService } from '../../services/test-run.service';
 import SpyObj = jasmine.SpyObj;
 import { TestBed } from '@angular/core/testing';
@@ -39,11 +34,11 @@ import {
   MOCK_DEVICE_VALUE,
   MOCK_INTERFACE_VALUE,
   MOCK_INTERFACES,
-  MOCK_INTERNET_OPTIONS,
   MOCK_LOG_VALUE,
   MOCK_PERIOD_VALUE,
   MOCK_SYSTEM_CONFIG_WITH_DATA,
   MOCK_SYSTEM_CONFIG_WITH_NO_DATA,
+  MOCK_SYSTEM_CONFIG_WITH_SINGLE_PORT,
 } from '../../mocks/settings.mock';
 
 describe('SettingsStore', () => {
@@ -120,7 +115,6 @@ describe('SettingsStore', () => {
         expect(store.interfaces).toEqual(MOCK_INTERFACES);
         expect(store.deviceOptions).toEqual(MOCK_INTERFACES);
         expect(store.internetOptions).toEqual({
-          '': 'Not specified',
           mockDeviceKey: 'mockDeviceValue',
           mockInternetKey: 'mockInternetValue',
         });
@@ -193,7 +187,7 @@ describe('SettingsStore', () => {
         settingsStore.viewModel$.pipe(skip(3), take(1)).subscribe(store => {
           expect(store.interfaces).toEqual(interfaces);
           expect(store.deviceOptions).toEqual(interfaces);
-          expect(store.internetOptions).toEqual(MOCK_INTERNET_OPTIONS);
+          expect(store.internetOptions).toEqual(interfaces);
           done();
         });
 
@@ -279,6 +273,27 @@ describe('SettingsStore', () => {
         });
       });
 
+      describe('with single port mode', () => {
+        beforeEach(() => {
+          settingsStore.setSystemConfig(MOCK_SYSTEM_CONFIG_WITH_SINGLE_PORT);
+          settingsStore.setInterfaces(MOCK_INTERFACES);
+        });
+
+        it('should disable internet control', () => {
+          const form = fb.group({
+            device_intf: ['value'],
+            internet_intf: [''],
+            log_level: [''],
+            monitor_period: ['value'],
+          });
+          settingsStore.setDefaultFormValues(form);
+
+          expect(
+            (form.get(FormKey.INTERNET) as FormControl).disabled
+          ).toBeTrue();
+        });
+      });
+
       describe('when values are empty', () => {
         beforeEach(() => {
           settingsStore.setSystemConfig(MOCK_SYSTEM_CONFIG_WITH_NO_DATA);
@@ -300,7 +315,7 @@ describe('SettingsStore', () => {
           });
           expect((form.get(FormKey.INTERNET) as FormControl).value).toEqual({
             key: '',
-            value: DEFAULT_INTERNET_OPTION[''],
+            value: undefined,
           });
           expect((form.get(FormKey.LOG_LEVEL) as FormControl).value).toEqual({
             key: 'INFO',
@@ -322,7 +337,6 @@ describe('SettingsStore', () => {
         mockNewInternetKey: 'mockNewInternetValue',
       };
       const updateInternetOptions = {
-        '': 'Not specified',
         mockDeviceKey: 'mockDeviceValue',
         mockNewInternetKey: 'mockNewInternetValue',
       };


### PR DESCRIPTION
### Overview

Ticket: 372768360
feat: [Settings] only device port is enabled in no internet mode

### Screenshots after changes
https://screenshot.googleplex.com/ABra7RNZmTnWD5j
https://screenshot.googleplex.com/5VYVZXZ4vsy8jSN

### Video after changes

#### - with one port mode
https://screencast.googleplex.com/cast/NTI4MDcwMDM4NjI0NjY1NnwyMTQ3YjUzZS05OA

#### - with two ports
https://screencast.googleplex.com/cast/NDkzNjkxOTg0NTY5OTU4NHwxYWY1OWExNC0zNQ