### PR TITLE
374258745: (fix) [PDF report] wrap long words into the next line to prevent cutting content

### DIFF
--- a/resources/report/test_report_styles.css
+++ b/resources/report/test_report_styles.css
@@ -211,6 +211,8 @@
       font-weight: 400;
       border-top: 1px solid #DADCE0;
       font-family: 'Roboto Mono', monospace;
+      word-wrap: break-word;
+      word-break: break-word;
     }
 
     div.steps-to-resolve {


### PR DESCRIPTION
### Overview

Ticket: 374258745
fix: [PDF report] wrap long words into the next line to prevent cutting content


### Screenshot before changes (in case of long words):
https://screenshot.googleplex.com/3KmSPmCwLkTtuNi

### Screenshot after changes 
- in case of long words:
https://screenshot.googleplex.com/3MCRzQyuN2cy5A5

- base view:
https://screenshot.googleplex.com/3Y5wAwJWFBMpybX
