### PR TITLE
Upload cert - error handling

### DIFF
--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -975,6 +975,13 @@ class Api:
           False, "A certificate with that common name already exists."
         )
 
+      # Returned when
+      elif str(e) == "Certificate is missing the organization name":
+        response.status_code = status.HTTP_400_BAD_REQUEST
+        return self._generate_msg(
+          False, "The certificate must contain the organization name"
+        )
+
       # Returned when unable to load PEM file
       else:
         response.status_code = status.HTTP_400_BAD_REQUEST

--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -975,7 +975,7 @@ class Api:
           False, "A certificate with that common name already exists."
         )
 
-      # Returned when
+      # Returned when organization name is missing
       elif str(e) == "Certificate is missing the organization name":
         response.status_code = status.HTTP_400_BAD_REQUEST
         return self._generate_msg(

--- a/framework/python/src/api/api.py
+++ b/framework/python/src/api/api.py
@@ -982,6 +982,13 @@ class Api:
           False, "The certificate must contain the organization name"
         )
 
+      # Returned when common name is missing
+      elif str(e) == "Certificate is missing the common name":
+        response.status_code = status.HTTP_400_BAD_REQUEST
+        return self._generate_msg(
+          False, "The certificate must contain the common name"
+        )
+
       # Returned when unable to load PEM file
       else:
         response.status_code = status.HTTP_400_BAD_REQUEST

--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -826,16 +826,22 @@ question {question.get('question')}''')
     # Parse bytes into x509 object
     cert = x509.load_pem_x509_certificate(content, default_backend())
 
-    # Extract required properties
-    common_name = cert.subject.get_attributes_for_oid(
-        NameOID.COMMON_NAME)[0].value
+    # Retrieve the subject list of attributes
+    common_name_attr = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+
+    # Raise an error if the common name attribute is missing
+    if not common_name_attr:
+      raise ValueError('Certificate is missing the common name')
+
+    # Extract the organization name value
+    common_name = common_name_attr[0].value
 
     # Check if any existing certificates have the same common name
     for cur_cert in self._certs:
       if common_name == cur_cert['name']:
         raise ValueError('A certificate with that name already exists')
 
-    # Retrieve the list of attributes
+    # Retrieve the issuer list of attributes
     issuer_attr = cert.issuer.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
 
     # Raise an error if the organization name attribute is missing

--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -826,7 +826,7 @@ question {question.get('question')}''')
     # Parse bytes into x509 object
     cert = x509.load_pem_x509_certificate(content, default_backend())
 
-    # Retrieve the subject list of attributes
+    # Retrieve the common name attributes from the subject
     common_name_attr = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
 
     # Raise an error if the common name attribute is missing
@@ -841,7 +841,7 @@ question {question.get('question')}''')
       if common_name == cur_cert['name']:
         raise ValueError('A certificate with that name already exists')
 
-    # Retrieve the issuer list of attributes
+    # Retrieve the organization name attributes from issuer
     issuer_attr = cert.issuer.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
 
     # Raise an error if the organization name attribute is missing

--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -835,8 +835,15 @@ question {question.get('question')}''')
       if common_name == cur_cert['name']:
         raise ValueError('A certificate with that name already exists')
 
-    issuer = cert.issuer.get_attributes_for_oid(
-        NameOID.ORGANIZATION_NAME)[0].value
+    # Retrieve the list of attributes
+    issuer_attr = cert.issuer.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
+
+    # Raise an error if the organization name attribute is missing
+    if not issuer_attr:
+      raise ValueError('Certificate is missing the organization name')
+
+    # Extract the organization name value
+    issuer = issuer_attr[0].value
 
     status = 'Valid'
     if now > cert.not_valid_after_utc:


### PR DESCRIPTION
Updated upload cert error handling:
-  if the organization name is missing
-  if the common name is missing