### PR TITLE
Scapy update to 2.6.0

### DIFF
--- a/framework/requirements.txt
+++ b/framework/requirements.txt
@@ -5,7 +5,7 @@ requests==2.32.3
 docker==7.1.0
 ipaddress==1.0.23
 netifaces==0.11.0
-scapy==2.5.0
+scapy==2.6.0
 
 # Requirments for the test_orc module
 weasyprint==61.2

--- a/testing/tests/test_tests
+++ b/testing/tests/test_tests
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set +o xtrace
+set -o xtrace
 ip a
 TEST_DIR=/tmp/results
 TESTRUN_DIR=/usr/local/testrun

--- a/testing/tests/test_tests
+++ b/testing/tests/test_tests
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -o xtrace
+set +o xtrace
 ip a
 TEST_DIR=/tmp/results
 TESTRUN_DIR=/usr/local/testrun


### PR DESCRIPTION
Updating to scapy from 2.5.0 to 2.6.0 removes the bellow warning:

/home/runner/work/testrun/testrun/venv/lib/python3.10/site-packages/scapy/layers/ipsec.py:512: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  cipher=algorithms.TripleDES,
/home/runner/work/testrun/testrun/venv/lib/python3.10/site-packages/scapy/layers/ipsec.py:516: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  cipher=algorithms.TripleDES,