### PR TITLE
Base container missing procps package

### DIFF
--- a/modules/test/base/base.Dockerfile
+++ b/modules/test/base/base.Dockerfile
@@ -68,7 +68,7 @@ RUN wget https://standards-oui.ieee.org/oui.txt -O /usr/local/etc/oui.txt || ech
 FROM python:3.10-slim
 
 # Install common software
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq net-tools iputils-ping tzdata tcpdump iproute2 jq dos2unix nmap wget --fix-missing
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -yq net-tools iputils-ping tzdata tcpdump iproute2 jq dos2unix nmap wget procps --fix-missing
 
 # Get the virtual environment from builder stage
 COPY --from=builder /opt/venv /opt/venv


### PR DESCRIPTION
Added procps package in the base container. 

Before (module.log for all test modules) 
![before](https://github.com/user-attachments/assets/e7f7f27d-36e6-4a05-8f2e-ecffc29a4928)

After (module.log for all test modules) 
![after](https://github.com/user-attachments/assets/3af139ae-811c-4567-bfd2-abb9a8d28a5f)
