### PR TITLE
Ipv6_slaac error handling

### DIFF
--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -16,6 +16,7 @@ import util
 import time
 import traceback
 import os
+from scapy.error import Scapy_Exception
 from scapy.all import rdpcap, DHCP, ARP, Ether, ICMP, IPv6, ICMPv6ND_NS
 from test_module import TestModule
 from dhcp1.client import Client as DHCPClient1
@@ -569,7 +570,9 @@ class ConnectionModule(TestModule):
     slac_test, sends_ipv6 = self._has_slaac_addres()
     if slac_test:
       result = True, f'Device has formed SLAAC address {self._device_ipv6_addr}'
-    if result is None:
+    elif slac_test is None:
+      result = 'Error', 'An error occurred whilst running this test'
+    else:
       if sends_ipv6:
         LOGGER.info('Device does not support IPv6 SLAAC')
         result = False, 'Device does not support IPv6 SLAAC'
@@ -584,8 +587,9 @@ class ConnectionModule(TestModule):
 
     try:
       packet_capture += rdpcap(DHCP_CAPTURE_FILE)
-    except FileNotFoundError:
-      LOGGER.error('dhcp-1.pcap not found, ignoring')
+    except (FileNotFoundError, Scapy_Exception):
+      LOGGER.error('dhcp-1.pcap not found or empty, ignoring')
+      return None, False
 
     sends_ipv6 = False
     for packet_number, packet in enumerate(packet_capture, start=1):


### PR DESCRIPTION
Added error handling if dhcp-1.pcap is empty.

Before
![scappy_error](https://github.com/user-attachments/assets/fd7e3a33-9c69-470b-bbf2-4c94053440ae)

After
![scappy_error_after](https://github.com/user-attachments/assets/2f4acb63-6106-4e6f-9f4a-1ac6f1085627)
