### PR TITLE
The test attempt name is truncated without option to read the full text while zooming in

### DIFF
--- a/modules/ui/src/app/pages/testrun/testrun.component.html
+++ b/modules/ui/src/app/pages/testrun/testrun.component.html
@@ -36,7 +36,10 @@ limitations under the License.
               "></ng-container>
           </div>
           <div class="toolbar-row bottom">
-            <h2 class="title progress-title" tabindex="-1">
+            <h2
+              class="title progress-title"
+              tabindex="-1"
+              [matTooltip]="getTestRunName(data)">
               {{ getTestRunName(data) }}
             </h2>
             <span *ngIf="data.tags?.length" class="toolbar-tag-container">

--- a/modules/ui/src/app/pages/testrun/testrun.component.scss
+++ b/modules/ui/src/app/pages/testrun/testrun.component.scss
@@ -90,6 +90,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
 }
 
 .toolbar-tag-container {


### PR DESCRIPTION
Adds tooltip for title
![5AQZy2uKdz3zGDu](https://github.com/user-attachments/assets/e7a8b741-c767-4c7b-8833-2cbbef7b4d68)
