### PR TITLE
Add BACnet test and extend port scan

### DIFF
--- a/modules/test/services/conf/module_config.json
+++ b/modules/test/services/conf/module_config.json
@@ -372,6 +372,22 @@
           "Disable the NTP server",
           "Drop traffic entering port 123/udp"
         ]
+      },
+      {
+        "name": "protocol.services.bacnet",
+        "test_description": "Report whether the device is running a BACnet server",
+        "expected_behavior": "The device may or may not be running a BACnet server",
+        "config": {
+          "services": [
+            "bacnet"
+          ],
+          "ports": [
+            {
+              "number": 47808,
+              "type": "udp"
+            }
+          ]
+        }
       }
     ]
   }

--- a/modules/test/services/python/src/services_module.py
+++ b/modules/test/services/python/src/services_module.py
@@ -420,3 +420,15 @@ class ServicesModule(TestModule):
           else:
             return (False,
                     f"SSH server found running {open_port_info['version']}")
+
+  def _protocol_services_bacnet(self, config):
+    LOGGER.info('Running protocol.services.bacnet')
+
+    open_ports = self._check_results(config['ports'], config['services'])
+    if len(open_ports) == 0:
+      return False, 'No BACnet server found'
+    else:
+      return (
+        True,
+        f'''Found BACnet server running on port {', '.join(open_ports)}'''
+      )

--- a/modules/test/services/python/src/services_module.py
+++ b/modules/test/services/python/src/services_module.py
@@ -196,10 +196,9 @@ class ServicesModule(TestModule):
       self._scan_results.update(self._scan_udp_results)
 
   def _scan_tcp_ports(self):
-    max_port = 10000
     LOGGER.info('Running nmap TCP port scan')
     nmap_results = util.run_command( # pylint: disable=E1120
-        f'''nmap --open -sT -sV -Pn -v -p 1-{max_port}
+        f'''nmap --open -sT -sV -Pn -v -p 1-65535
       --version-intensity 7 -T4 -oX - {self._ipv4_addr}''')[0]
 
     LOGGER.info('TCP port scan complete')

--- a/modules/test/services/python/src/services_module.py
+++ b/modules/test/services/python/src/services_module.py
@@ -224,7 +224,7 @@ class ServicesModule(TestModule):
     if len(ports) > 0:
       port_list = ','.join(ports)
       LOGGER.info('Running nmap UDP port scan')
-      LOGGER.debug('UDP ports: ' + str(port_list))
+      LOGGER.info('UDP ports: ' + str(port_list))
       nmap_results = util.run_command( # pylint: disable=E1120
           f'nmap -sU -sV -p {port_list} -oX - {self._ipv4_addr}')[0]
       LOGGER.info('UDP port scan complete')


### PR DESCRIPTION
Scans all TCP ports and adds an extra nmap test to cover the BACnet port scan. The intention is for the bacnet test to not actually run, as it is not included in any of the test packs. This is dependent on #956 but will work without it.