### PR TITLE
conn/ipv6_slaac

### DIFF
--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -572,7 +572,7 @@ class ConnectionModule(TestModule):
     LOGGER.info('Running connection.ipv6_slaac')
     result = None
 
-    slac_test, sends_ipv6 = self._has_slaac_addres()
+    slac_test, sends_ipv6 = self._has_slaac_address()
     if slac_test:
       result = True, f'Device has formed SLAAC address {self._device_ipv6_addr}'
     elif slac_test is None:
@@ -586,7 +586,7 @@ class ConnectionModule(TestModule):
         result = False, 'Device does not support IPv6'
     return result
 
-  def _has_slaac_addres(self):
+  def _has_slaac_address(self):
     packet_capture = (rdpcap(self.startup_capture_file) +
                       rdpcap(self.monitor_capture_file))
 

--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -594,7 +594,6 @@ class ConnectionModule(TestModule):
       packet_capture += rdpcap(DHCP_CAPTURE_FILE)
     except (FileNotFoundError, Scapy_Exception):
       LOGGER.error('dhcp-1.pcap not found or empty, ignoring')
-      return None, False
 
     sends_ipv6 = False
     for packet_number, packet in enumerate(packet_capture, start=1):


### PR DESCRIPTION
There are instances when dhcp-1.pcap is empty or not created. Removed the return line to allow the test to continue and check for IPv6 address in monitor.pacp and startup.pcap files if dhcp-1.pcap has no packets or is not found.

Before (the test stopped after the error)
![before_slaac](https://github.com/user-attachments/assets/b46b06dd-a1a1-498a-9f82-3b58b7b95bac)

After (the test continued after the error)
![After_slaac](https://github.com/user-attachments/assets/81c1965b-d3b8-47bb-b999-d06f7bf3b1c6)
