### PR TITLE
Fix tls error result

### DIFF
--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -237,13 +237,16 @@ class TLSModule(TestModule):
           tls_1_2_results, tls_1_3_results)
       # Determine results and return proper messaging and details
       description = ''
-      if results[0] is None:
+      result = results[0]
+      details = results[1]
+      if result is None:
+        result = 'Feature Not Detected'
         description = 'TLS 1.2 certificate could not be validated'
-      elif results[0]:
+      elif result:
         description = 'TLS 1.2 certificate is valid'
       else:
         description = 'TLS 1.2 certificate is invalid'
-      return results[0], description, results[1]
+      return result, description, details
 
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
@@ -258,13 +261,17 @@ class TLSModule(TestModule):
                                                    tls_version='1.3')
       # Determine results and return proper messaging and details
       description = ''
-      if results[0] is None:
+      result = results[0]
+      details = results[1]
+      description = ''
+      if result is None:
+        result = 'Feature Not Detected'
         description = 'TLS 1.3 certificate could not be validated'
       elif results[0]:
         description = 'TLS 1.3 certificate is valid'
       else:
         description = 'TLS 1.3 certificate is invalid'
-      return results[0], description, results[1]
+      return result, description, details
 
     else:
       LOGGER.error('Could not resolve device IP address')


### PR DESCRIPTION
Fixes error result for TLS server tests when no certificate can be validated.

Current results:
![image](https://github.com/user-attachments/assets/12bc4b74-928d-48ac-9d23-7709e0a9db0e)


After fix:
![Screenshot 2024-11-08 161222](https://github.com/user-attachments/assets/e05066a5-469c-49ba-985e-dbc8d9eed87f)
