### PR TITLE
Error handling when lease is None

### DIFF
--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -873,9 +873,8 @@ class ConnectionModule(TestModule):
       else:
         LOGGER.info('New lease not found. Waiting to check again')
 
-    except Exception as e:  # pylint: disable=W0718
-      LOGGER.error('Failed to restore DHCP server configuration: ' + str(e))
-      LOGGER.error(traceback.format_exc())
+    except Exception:  # pylint: disable=W0718
+      LOGGER.error('Failed to restore DHCP server configuration')
 
     return final_result, final_result_details
 

--- a/modules/test/conn/python/src/dhcp_util.py
+++ b/modules/test/conn/python/src/dhcp_util.py
@@ -273,9 +273,11 @@ class DHCPUtil():
 
       LOGGER.info('Time until lease expiration: ' + str(wait_time))
       LOGGER.info('Waiting for current lease to expire: ' + str(expiration))
+
       if wait_time > 0:
         time.sleep(wait_time)
       LOGGER.info('Current lease expired')
+
     except TypeError:
       LOGGER.error('Device does not have an active lease')
 

--- a/modules/test/conn/python/src/dhcp_util.py
+++ b/modules/test/conn/python/src/dhcp_util.py
@@ -257,24 +257,27 @@ class DHCPUtil():
 
   def wait_for_lease_expire(self, lease, max_wait_time=30):
 
-    expiration_utc = datetime.strptime(lease['expires'], '%Y-%m-%d %H:%M:%S')
+    try:
+      expiration_utc = datetime.strptime(lease['expires'], '%Y-%m-%d %H:%M:%S')
 
-    # Lease information stored in UTC so we need to convert to local time
-    expiration = self.utc_to_local(expiration_utc)
-    time_to_expire = expiration - datetime.now(tz=tz.tzlocal())
+      # Lease information stored in UTC so we need to convert to local time
+      expiration = self.utc_to_local(expiration_utc)
+      time_to_expire = expiration - datetime.now(tz=tz.tzlocal())
 
-    # Wait until the expiration time and padd 5 seconds
-    # If wait time is longer than max_wait_time, only wait
-    # for the max wait time
-    wait_time = min(max_wait_time,
-                    time_to_expire.total_seconds() +
-                    5) if time_to_expire.total_seconds() > 0 else 0
+      # Wait until the expiration time and padd 5 seconds
+      # If wait time is longer than max_wait_time, only wait
+      # for the max wait time
+      wait_time = min(max_wait_time,
+                      time_to_expire.total_seconds() +
+                      5) if time_to_expire.total_seconds() > 0 else 0
 
-    LOGGER.info('Time until lease expiration: ' + str(wait_time))
-    LOGGER.info('Waiting for current lease to expire: ' + str(expiration))
-    if wait_time > 0:
-      time.sleep(wait_time)
-    LOGGER.info('Current lease expired.')
+      LOGGER.info('Time until lease expiration: ' + str(wait_time))
+      LOGGER.info('Waiting for current lease to expire: ' + str(expiration))
+      if wait_time > 0:
+        time.sleep(wait_time)
+      LOGGER.info('Current lease expired')
+    except TypeError:
+      LOGGER.error('Device does not have an active lease')
 
   # Convert from a UTC datetime to the local time zone
   def utc_to_local(self, utc_datetime):


### PR DESCRIPTION
LOGGER.error(traceback.format_exc()) line from _run_subnet_test in the connection_module.py is causing the traceback errror message to be displayed in the connection module.log looking like is a traceback error that wasn't handled. This error was handled by exception block from _run_subnet_test and it happens when the lease is None 
![connection_module_log](https://github.com/user-attachments/assets/4bb7dde5-2139-4826-b4cc-914b9e5012ca)

Updated for this TypeError to be handled in dhcp_util.py
