### PR TITLE
connection.private_test

### DIFF
--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -835,7 +835,7 @@ class ConnectionModule(TestModule):
       else:
         if result['result'] is not None:
           final_result &= result['result']
-        if result['result']:
+        if not result['result']:
           final_result_details += result['details'] + '\n'
 
     if final_result:


### PR DESCRIPTION
When connection.private_test is non compliant the default test_description is being recorded in the report
![connection_private_test](https://github.com/user-attachments/assets/33ec2d29-a7bd-4135-baaa-d5267b5f51cd)

![connection_private_test2](https://github.com/user-attachments/assets/29a4ed52-62a3-4113-b3a7-8aa24abdcbd9)

  This is happening because final_result_details empty  string isn't updated when result['result'] is false 