### PR TITLE
Switch src ip to src mac for TLS client testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Testrun provides the network and assistive tools for engineers when manual testi
 ## Hardware
 
 -  PC running Ubuntu LTS 20.04, 22.04, or 24.04 (laptop or desktop)
--  2x USB Ethernet adapter (one may be built-in Ethernet)
+-  2x ethernet ports (USB ethernet adapters work too)
 -  Internet connection
 
 ## Software

--- a/cmd/build_ui
+++ b/cmd/build_ui
@@ -33,6 +33,5 @@ echo "Building the user interface"
 # Start build container and build the ui dist
 docker run --rm -v "$(pwd)"/modules/ui:/modules/ui testrun/build-ui /bin/sh -c "npm install && npm run build"
 
-
 # Kill the container (Should not be running anymore)
 docker kill tr-ui-build 2> /dev/null || true

--- a/cmd/build_ui
+++ b/cmd/build_ui
@@ -30,8 +30,9 @@ docker kill tr-ui-build 2> /dev/null || true
 
 echo "Building the user interface"
 
-# Start build container and build the ui dist 
-docker run --rm -v $PWD/modules/ui:/modules/ui testrun/build-ui /bin/sh -c "npm install && npm run build"
+# Start build container and build the ui dist
+docker run --rm -v "$(pwd)"/modules/ui:/modules/ui testrun/build-ui /bin/sh -c "npm install && npm run build"
+
 
 # Kill the container (Should not be running anymore)
 docker kill tr-ui-build 2> /dev/null || true

--- a/cmd/package
+++ b/cmd/package
@@ -22,6 +22,12 @@ if [[ "$EUID" == 0 ]]; then
     exit 1
 fi
 
+# Check that user is in docker group
+if ! (id -nGz "$USER" | grep -qzxF "docker"); then
+echo User is not in docker group. Follow https://docs.docker.com/engine/install/linux-postinstall/ to finish setting up docker.
+exit 1
+fi
+
 MAKE_SRC_DIR=make
 MAKE_CONTROL_DIR=make/DEBIAN/control
 

--- a/cmd/package
+++ b/cmd/package
@@ -24,8 +24,8 @@ fi
 
 # Check that user is in docker group
 if ! (id -nGz "$USER" | grep -qzxF "docker"); then
-echo User is not in docker group. Follow https://docs.docker.com/engine/install/linux-postinstall/ to finish setting up docker.
-exit 1
+    echo User is not in docker group. Follow https://docs.docker.com/engine/install/linux-postinstall/ to finish setting up docker.
+    exit 1
 fi
 
 MAKE_SRC_DIR=make

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -21,7 +21,7 @@ We recommend that you run Testrun on a stand-alone machine that has a fresh inst
 Before you start, ensure you have the following hardware:
 
 -  PC running Ubuntu LTS (laptop or desktop)
--  2x USB Ethernet adapter (one may be a built-in Ethernet port)
+-  2x ethernet ports (USB ethernet adapters work too)
 -  Internet connection
 
 ![Required hardware for Testrun](/docs/ui/getstarted--2dn8vrzsspe.png)

--- a/modules/test/tls/bin/get_client_hello_packets.sh
+++ b/modules/test/tls/bin/get_client_hello_packets.sh
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 CAPTURE_FILE="$1"
-SRC_IP="$2"
+SRC_MAC="$2"
 TLS_VERSION="$3"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
-TSHARK_FILTER="ssl.handshake.type==1 and ip.src==$SRC_IP"
+TSHARK_FILTER="ssl.handshake.type==1 and eth.src==$SRC_MAC"
 
 if [[ $TLS_VERSION == '1.0' ]]; then
   TSHARK_FILTER="$TSHARK_FILTER and ssl.handshake.version==0x0301"

--- a/modules/test/tls/bin/get_non_tls_client_connections.sh
+++ b/modules/test/tls/bin/get_non_tls_client_connections.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 CAPTURE_FILE="$1"
-SRC_IP="$2"
+SRC_MAC="$2"
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 # Filter out TLS, DNS and NTP, ICMP (ping), braodcast and multicast packets
@@ -24,9 +24,8 @@ TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
 # - Multicast and braodcast protocols are not typically encrypted so we aren't expecting them to
 #   be over TLS connections
 # - ICMP (ping) requests are not encrypted so we also need to ignore these
-TSHARK_FILTER="ip.src == $SRC_IP and not tls and not dns and not ntp and not icmp and not(ip.dst == 224.0.0.0/4 or ip.dst == 255.255.255.255)"
+TSHARK_FILTER="eth.src == $SRC_MAC and not tls and not dns and not ntp and not icmp and not(ip.dst == 224.0.0.0/4 or ip.dst == 255.255.255.255)"
 
 response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
-  	

--- a/modules/test/tls/bin/get_tls_client_connections.sh
+++ b/modules/test/tls/bin/get_tls_client_connections.sh
@@ -29,4 +29,3 @@ fi
 response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
-  	

--- a/modules/test/tls/bin/get_tls_client_connections.sh
+++ b/modules/test/tls/bin/get_tls_client_connections.sh
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 CAPTURE_FILE="$1"
-SRC_IP="$2"
+SRC_MAC="$2"
 PROTOCOL=$3
 
 TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
-TSHARK_FILTER="ip.src == $SRC_IP and tls"
+TSHARK_FILTER="eth.src == $SRC_MAC and tls"
 
 # Add a protocol filter if defined	
 if [ -n "$PROTOCOL" ];then

--- a/modules/test/tls/bin/get_tls_packets.sh
+++ b/modules/test/tls/bin/get_tls_packets.sh
@@ -16,13 +16,13 @@
 
 
 CAPTURE_FILE="$1"
-SRC_IP="$2"
+SRC_MAC="$2"
 TLS_VERSION="$3"
 
-TSHARK_OUTPUT="-T json -e ip.src -e tcp.dstport -e ip.dst"
+TSHARK_OUTPUT="-T json -e eth.src -e tcp.dstport -e ip.dst"
 # Handshakes will still report TLS version 1 even for TLS 1.2 connections
 # so we need to filter thes out
-TSHARK_FILTER="ip.src==$SRC_IP and ssl.handshake.type!=1"
+TSHARK_FILTER="eth.src==$SRC_MAC and ssl.handshake.type!=1"
 
 if [ $TLS_VERSION == '1.0' ];then
 	TSHARK_FILTER="$TSHARK_FILTER and ssl.record.version==0x0301"
@@ -37,4 +37,3 @@ fi
 response=$(tshark -r "$CAPTURE_FILE" $TSHARK_OUTPUT $TSHARK_FILTER)
 
 echo "$response"
-  	

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -440,71 +440,53 @@ class TLSModule(TestModule):
 
   def _security_tls_v1_0_client(self):
     LOGGER.info('Running security.tls.v1_0_client')
-    self._resolve_device_ip()
-    # If the ipv4 address wasn't resolved yet, try again
-    if self._device_ipv4_addr is not None:
-      tls_1_0_valid = self._validate_tls_client(self._device_ipv4_addr, '1.0')
-      tls_1_1_valid = self._validate_tls_client(self._device_ipv4_addr, '1.1')
-      tls_1_2_valid = self._validate_tls_client(self._device_ipv4_addr, '1.2')
-      tls_1_3_valid = self._validate_tls_client(self._device_ipv4_addr, '1.3')
-      states = [
-          tls_1_0_valid[0], tls_1_1_valid[0], tls_1_2_valid[0], tls_1_3_valid[0]
-      ]
-      if any(state is True for state in states):
-        # If any state is True, return True
-        result_state = True
-        result_message = 'TLS 1.0 or higher detected'
-      elif all(state == 'Feature Not Detected' for state in states):
-        # If all states are "Feature not Detected"
-        result_state = 'Feature Not Detected'
-        result_message = tls_1_0_valid[1]
-      elif all(state == 'Error' for state in states):
-        # If all states are "Error"
-        result_state = 'Error'
-        result_message = ''
-      else:
-        result_state = False
-        result_message = 'TLS 1.0 or higher was not detected'
-      result_details = tls_1_0_valid[2] + tls_1_1_valid[2] + tls_1_2_valid[
-          2] + tls_1_3_valid[2]
-      result_tags = list(
-          set(tls_1_0_valid[3] + tls_1_1_valid[3] + tls_1_2_valid[3] +
-              tls_1_3_valid[3]))
-      return result_state, result_message, result_details, result_tags
+    tls_1_0_valid = self._validate_tls_client(self._device_mac, '1.0')
+    tls_1_1_valid = self._validate_tls_client(self._device_mac, '1.1')
+    tls_1_2_valid = self._validate_tls_client(self._device_mac, '1.2')
+    tls_1_3_valid = self._validate_tls_client(self._device_mac, '1.3')
+    states = [
+        tls_1_0_valid[0], tls_1_1_valid[0], tls_1_2_valid[0], tls_1_3_valid[0]
+    ]
+    if any(state is True for state in states):
+      # If any state is True, return True
+      result_state = True
+      result_message = 'TLS 1.0 or higher detected'
+    elif all(state == 'Feature Not Detected' for state in states):
+      # If all states are "Feature not Detected"
+      result_state = 'Feature Not Detected'
+      result_message = tls_1_0_valid[1]
+    elif all(state == 'Error' for state in states):
+      # If all states are "Error"
+      result_state = 'Error'
+      result_message = ''
     else:
-      LOGGER.error('Could not resolve device IP address. Skipping')
-      return 'Error', 'Could not resolve device IP address'
+      result_state = False
+      result_message = 'TLS 1.0 or higher was not detected'
+    result_details = tls_1_0_valid[2] + tls_1_1_valid[2] + tls_1_2_valid[
+        2] + tls_1_3_valid[2]
+    result_tags = list(
+        set(tls_1_0_valid[3] + tls_1_1_valid[3] + tls_1_2_valid[3] +
+            tls_1_3_valid[3]))
+    return result_state, result_message, result_details, result_tags
 
   def _security_tls_v1_2_client(self):
     LOGGER.info('Running security.tls.v1_2_client')
-    self._resolve_device_ip()
-    # If the ipv4 address wasn't resolved yet, try again
-    if self._device_ipv4_addr is not None:
-      return self._validate_tls_client(self._device_ipv4_addr,
-                                       '1.2',
-                                       unsupported_versions=['1.0', '1.1'])
-    else:
-      LOGGER.error('Could not resolve device IP address. Skipping')
-      return 'Error', 'Could not resolve device IP address'
+    return self._validate_tls_client(self._device_ipv4_addr,
+                                      '1.2',
+                                      unsupported_versions=['1.0', '1.1'])
 
   def _security_tls_v1_3_client(self):
     LOGGER.info('Running security.tls.v1_3_client')
-    self._resolve_device_ip()
-    # If the ipv4 address wasn't resolved yet, try again
-    if self._device_ipv4_addr is not None:
-      return self._validate_tls_client(self._device_ipv4_addr,
-                                       '1.3',
-                                       unsupported_versions=['1.0', '1.1'])
-    else:
-      LOGGER.error('Could not resolve device IP address. Skipping')
-      return 'Error', 'Could not resolve device IP address'
+    return self._validate_tls_client(self._device_ipv4_addr,
+                                      '1.3',
+                                      unsupported_versions=['1.0', '1.1'])
 
   def _validate_tls_client(self,
-                           client_ip,
+                           client_mac,
                            tls_version,
                            unsupported_versions=None):
     client_results = self._tls_util.validate_tls_client(
-        client_ip=client_ip,
+        client_mac=client_mac,
         tls_version=tls_version,
         capture_files=[
             MONITOR_CAPTURE_FILE, STARTUP_CAPTURE_FILE, TLS_CAPTURE_FILE

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -471,13 +471,13 @@ class TLSModule(TestModule):
 
   def _security_tls_v1_2_client(self):
     LOGGER.info('Running security.tls.v1_2_client')
-    return self._validate_tls_client(self._device_ipv4_addr,
+    return self._validate_tls_client(self._device_mac,
                                       '1.2',
                                       unsupported_versions=['1.0', '1.1'])
 
   def _security_tls_v1_3_client(self):
     LOGGER.info('Running security.tls.v1_3_client')
-    return self._validate_tls_client(self._device_ipv4_addr,
+    return self._validate_tls_client(self._device_mac,
                                       '1.3',
                                       unsupported_versions=['1.0', '1.1'])
 

--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -817,7 +817,8 @@ class TLSUtil():
           LOGGER.info(f'''TLS connection detected to {ip}.
                        Ignoring non-TLS traffic detected to this IP''')
 
-    unsupported_tls_ips = self.get_unsupported_tls_ips(client_mac, capture_files,
+    unsupported_tls_ips = self.get_unsupported_tls_ips(client_mac,
+                                                       capture_files,
                                                        unsupported_versions)
     if len(unsupported_tls_ips) > 0:
       tls_client_valid = False

--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -543,7 +543,7 @@ class TLSUtil():
       response = util.run_command(command)
       packets = response[0].strip()
       parsed_json = json.loads(packets)
-        # Parse each packet and append key-value pairs to combined_results
+      # Parse each packet and append key-value pairs to combined_results
       result = self.parse_packets(parsed_json, capture_file)
       combined_results.extend(result)
     return combined_results

--- a/modules/test/tls/python/src/tls_util.py
+++ b/modules/test/tls/python/src/tls_util.py
@@ -475,11 +475,11 @@ class TLSUtil():
     ciphers = response[0].split('\n')
     return ciphers
 
-  def get_hello_packets(self, capture_files, src_ip, tls_version):
+  def get_hello_packets(self, capture_files, src_mac, tls_version):
     combined_results = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_client_hello_packets.sh'
-      args = f'"{capture_file}" {src_ip} {tls_version}'
+      args = f'"{capture_file}" {src_mac} {tls_version}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
       packets = response[0].strip()
@@ -501,11 +501,11 @@ class TLSUtil():
     return combined_results
 
   # Resolve all connections from the device that don't use TLS
-  def get_non_tls_packetes(self, client_ip, capture_files):
+  def get_non_tls_packetes(self, client_mac, capture_files):
     combined_packets = []
     for capture_file in capture_files:
       bin_file = self._bin_dir + '/get_non_tls_client_connections.sh'
-      args = f'"{capture_file}" {client_ip}'
+      args = f'"{capture_file}" {client_mac}'
       command = f'{bin_file} {args}'
       response = util.run_command(command)
       if len(response) > 0:
@@ -615,16 +615,12 @@ class TLSUtil():
   # we will assume any local connections using the same IP subnet as our
   # local network are approved and only connections to IP addresses outside
   # our network will be flagged.
-  def get_non_tls_client_connection_ips(self, client_ip, capture_files):
+  def get_non_tls_client_connection_ips(self, client_mac, capture_files):
     LOGGER.info('Checking client for non-TLS client connections')
-    packets = self.get_non_tls_packetes(client_ip=client_ip,
+    packets = self.get_non_tls_packetes(client_mac=client_mac,
                                         capture_files=capture_files)
 
     # Extract the subnet from the client IP address
-    src_ip = ipaddress.ip_address(client_ip)
-    src_subnet = ipaddress.ip_network(src_ip, strict=False)
-    subnet_with_mask = ipaddress.ip_network(
-        src_subnet, strict=False).supernet(new_prefix=24)
 
     non_tls_dst_ips = set()  # Store unique destination IPs
     for packet in packets:
@@ -633,6 +629,13 @@ class TLSUtil():
         tcp_flags = packet['_source']['layers']['tcp.flags']
         if 'A' not in tcp_flags and 'S' not in tcp_flags:
           # Packet is not ACK or SYN
+
+          src_ip = ipaddress.ip_address(
+            packet['_source']['layers']['ip.src'][0])
+          src_subnet = ipaddress.ip_network(src_ip, strict=False)
+          subnet_with_mask = ipaddress.ip_network(
+              src_subnet, strict=False).supernet(new_prefix=24)
+
           dst_ip = ipaddress.ip_address(
               packet['_source']['layers']['ip.dst'][0])
           if not dst_ip in subnet_with_mask:
@@ -645,14 +648,14 @@ class TLSUtil():
   # local network are approved and only connections to IP addresses outside
   # our network will be flagged.
   def get_unsupported_tls_ips(self,
-                              client_ip,
+                              client_mac,
                               capture_files,
                               unsupported_versions=None):
     LOGGER.info('Checking client for unsupported TLS client connections')
     unsupported_tls_dst_ips = {}
     if unsupported_versions is not None:
       for unsupported_version in unsupported_versions:
-        tls_packets = self.get_tls_packets(capture_files, client_ip, '1.0')
+        tls_packets = self.get_tls_packets(capture_files, client_mac, '1.0')
         if len(tls_packets) > 0:
           for packet in tls_packets:
             dst_ip = packet['dst_ip']
@@ -708,18 +711,18 @@ class TLSUtil():
     return False
 
   def validate_tls_client(self,
-                          client_ip,
+                          client_mac,
                           tls_version,
                           capture_files,
                           unsupported_versions=None):
     LOGGER.info('Validating client for TLS: ' + tls_version)
-    hello_packets = self.get_hello_packets(capture_files, client_ip,
+    hello_packets = self.get_hello_packets(capture_files, client_mac,
                                            tls_version)
 
     # Resolve allowed protocol connections that require
     # additional consideration beyond packet inspection
     protocol_client_ips = (self.get_allowed_protocol_client_connection_ips(
-        client_ip, capture_files))
+        client_mac, capture_files))
 
     if len(protocol_client_ips) > 0:
       LOGGER.info(
@@ -790,10 +793,10 @@ class TLSUtil():
 
     # Resolve all non-TLS related client connections
     non_tls_client_ips = self.get_non_tls_client_connection_ips(
-        client_ip, capture_files)
+        client_mac, capture_files)
 
     # Resolve all TLS related client connections
-    tls_client_ips = self.get_tls_client_connection_ips(client_ip,
+    tls_client_ips = self.get_tls_client_connection_ips(client_mac,
                                                         capture_files)
     # Filter out all outbound TLS connections regardless on whether
     # or not they were validated.  If they were not validated,
@@ -814,7 +817,7 @@ class TLSUtil():
           LOGGER.info(f'''TLS connection detected to {ip}.
                        Ignoring non-TLS traffic detected to this IP''')
 
-    unsupported_tls_ips = self.get_unsupported_tls_ips(client_ip, capture_files,
+    unsupported_tls_ips = self.get_unsupported_tls_ips(client_mac, capture_files,
                                                        unsupported_versions)
     if len(unsupported_tls_ips) > 0:
       tls_client_valid = False

--- a/testing/unit/tls/tls_module_test.py
+++ b/testing/unit/tls/tls_module_test.py
@@ -200,6 +200,7 @@ class TLSModuleTest(unittest.TestCase):
     self.assertFalse(test_results[0])
 
     # Test 1.2 server when 1.3 and 1.2 failed connection is established
+
   def security_tls_v1_2_none_server_test(self):
     tls_1_2_results = None, 'No cert'
     tls_1_3_results = None, 'No cert'
@@ -228,7 +229,7 @@ class TLSModuleTest(unittest.TestCase):
     capture_file = os.path.join(CAPTURES_DIR, 'no_tls.pcap')
 
     # Run the client test
-    test_results = TLS_UTIL.validate_tls_client(client_ip='172.27.253.167',
+    test_results = TLS_UTIL.validate_tls_client(client_mac='00:15:5d:0c:86:b9',
                                                 tls_version='1.2',
                                                 capture_files=[capture_file])
     print(str(test_results))
@@ -272,8 +273,8 @@ class TLSModuleTest(unittest.TestCase):
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     capture_file = OUTPUT_DIR + '/client_tls.pcap'
 
-    # Resolve the client ip used
-    client_ip = self.get_interface_ip(INTERNET_IFACE)
+    # Resolve the client mac used
+    client_mac = self.get_interface_mac(INTERNET_IFACE)
 
     # Genrate TLS outbound traffic
     if tls_generate is None:
@@ -281,7 +282,7 @@ class TLSModuleTest(unittest.TestCase):
     self.generate_tls_traffic(capture_file, tls_generate, disable_valid_ciphers)
 
     # Run the client test
-    return TLS_UTIL.validate_tls_client(client_ip=client_ip,
+    return TLS_UTIL.validate_tls_client(client_mac=client_mac,
                                         tls_version=tls_version,
                                         capture_files=[capture_file])
 
@@ -290,7 +291,7 @@ class TLSModuleTest(unittest.TestCase):
     capture_file = os.path.join(CAPTURES_DIR, 'monitor.pcap')
 
     # Run the client test
-    test_results = TLS_UTIL.validate_tls_client(client_ip='10.10.10.14',
+    test_results = TLS_UTIL.validate_tls_client(client_mac='70:b3:d5:96:c0:00',
                                                 tls_version='1.2',
                                                 capture_files=[capture_file])
     print(str(test_results))
@@ -303,7 +304,7 @@ class TLSModuleTest(unittest.TestCase):
     capture_file = os.path.join(CAPTURES_DIR, 'unsupported_tls.pcap')
 
     # Run the client test
-    test_results = TLS_UTIL.validate_tls_client(client_ip='172.27.253.167',
+    test_results = TLS_UTIL.validate_tls_client(client_mac='00:15:5d:0c:86:b9',
                                                 tls_version='1.2',
                                                 capture_files=[capture_file])
     print(str(test_results))
@@ -316,7 +317,7 @@ class TLSModuleTest(unittest.TestCase):
     capture_file = os.path.join(CAPTURES_DIR, 'monitor_with_quic.pcap')
 
     # Run the client test
-    test_results = TLS_UTIL.validate_tls_client(client_ip='10.10.10.15',
+    test_results = TLS_UTIL.validate_tls_client(client_mac='e4:5f:01:5f:92:9c',
                                                 tls_version='1.2',
                                                 capture_files=[capture_file])
     print(str(test_results))
@@ -525,11 +526,11 @@ class TLSModuleTest(unittest.TestCase):
 
     return capture_thread
 
-  def get_interface_ip(self, interface_name):
+  def get_interface_mac(self, interface_name):
     try:
       addresses = netifaces.ifaddresses(interface_name)
-      ipv4 = addresses[netifaces.AF_INET][0]['addr']
-      return ipv4
+      mac = addresses[netifaces.AF_LINK][0]['addr']
+      return mac
     except (ValueError, KeyError) as e:
       print(f'Error: {e}')
       return None


### PR DESCRIPTION
In this PR:
 - All TLS client scripts now use the source ethernet address instead of the ip address
 - Added an error message if there is a space in the file path when running cmd/package
 - Removed the requirement for usb ethernet adapter in the docs
 - Checks that the user is in the docker group when running cmd/package