### PR TITLE
[GM3] The icon for warning callouts differs from the icons of other callouts

### DIFF
--- a/modules/ui/src/app/components/callout/callout.component.html
+++ b/modules/ui/src/app/components/callout/callout.component.html
@@ -17,8 +17,7 @@ limitations under the License.
   <mat-icon
     *ngIf="type() !== CalloutType.InfoPilot"
     class="callout-icon"
-    fontSet="material-icons-outlined"
-    color="primary">
+    fontSet="material-symbols-outlined">
     {{ type() }}
   </mat-icon>
   <span

--- a/modules/ui/src/app/components/callout/callout.component.scss
+++ b/modules/ui/src/app/components/callout/callout.component.scss
@@ -33,28 +33,27 @@
 }
 
 .check_circle {
-  border-color: colors.$on-tertiary-container;
   color: colors.$on-tertiary-container;
   background-color: rgba(20, 108, 46, 0.1);
 }
 
 .info {
-  border-color: colors.$primary;
   color: colors.$primary;
   background-color: rgba(127, 207, 255, 0.16);
 }
 
-.error,
-.error_outline {
-  border-color: colors.$on-error-container;
+.error {
   color: colors.$on-error-container;
   background-color: rgba(179, 38, 30, 0.1);
 }
 
-.warning_amber {
-  border-color: colors.$orange-60;
+.warning {
   color: colors.$orange-40;
   background-color: colors.$orange-98;
+}
+
+.warning .callout-border {
+  color: colors.$orange-60;
 }
 
 .callout-container {

--- a/modules/ui/src/app/components/version/consent-dialog/consent-dialog.component.scss
+++ b/modules/ui/src/app/components/version/consent-dialog/consent-dialog.component.scss
@@ -36,7 +36,7 @@
   align-items: start !important;
 
   &.check_circle,
-  &.warning_amber {
+  &.warning {
     padding-top: 16px;
   }
 }

--- a/modules/ui/src/app/model/callout-type.ts
+++ b/modules/ui/src/app/model/callout-type.ts
@@ -17,7 +17,6 @@ export enum CalloutType {
   Info = 'info',
   InfoPilot = 'info pilot',
   Check = 'check_circle',
-  Warning = 'warning_amber',
+  Warning = 'warning',
   Error = 'error',
-  ErrorOutline = 'error_outline',
 }

--- a/modules/ui/src/app/pages/general-settings/general-settings.component.html
+++ b/modules/ui/src/app/pages/general-settings/general-settings.component.html
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <div class="setting-drawer-content" *ngIf="viewModel$ | async as vm">
   <app-callout
-    [type]="CalloutType.ErrorOutline"
+    [type]="CalloutType.Error"
     *ngIf="settingsDisable"
     action="Go to Testing tab"
     (onAction)="navigateToRuntime()">

--- a/modules/ui/src/app/pages/testrun/components/testrun-table/testrun-table.component.html
+++ b/modules/ui/src/app/pages/testrun/components/testrun-table/testrun-table.component.html
@@ -50,7 +50,7 @@ limitations under the License.
             "></ng-container>
         </mat-expansion-panel-header>
         <div class="expansion-panel-content cel-description">
-          <app-callout [type]="CalloutType.ErrorOutline">
+          <app-callout [type]="CalloutType.Error">
             Steps to resolve
             <ul class="cel-description-list">
               <li *ngFor="let point of item.recommendations">{{ point }}</li>


### PR DESCRIPTION
Change border color for warning callout; change icon for error callouts

before
![5uWWSEyBttzjTzR](https://github.com/user-attachments/assets/6c85569b-ced1-4101-804b-c600ad45010e)
![9qaYwK4fJho8DFW](https://github.com/user-attachments/assets/94878cc2-3cab-402b-b927-a25642fef9d6)

after
![3EVhFy8RRVrmugm](https://github.com/user-attachments/assets/b328c028-f1e0-4019-a5d1-8b56957e011e)
![3cVyuvF5icudmob](https://github.com/user-attachments/assets/0a0db877-4e98-4143-b574-c2191c7d5a88)
