### PR TITLE
Handling error if profile name contains special characters

### DIFF
--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -156,7 +156,7 @@ class TestrunSession():
 
   def start(self):
     self.reset()
-    self._status = TestrunStatus.STARTING
+    self._status = TestrunStatus.WAITING_FOR_DEVICE
     self._started = datetime.datetime.now()
 
   def get_started(self):

--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -604,12 +604,6 @@ class TestrunSession():
 
     profile_name = profile_json['name']
 
-    # Check if profile name has special characters
-    for char in profile_name:
-      if char in r"\<>?/:;@''][=^!":
-        LOGGER.error('Profile name should not contain special characters')
-        return None
-
     # Add version, timestamp and status
     profile_json['version'] = self.get_version()
     profile_json['created'] = datetime.datetime.now().strftime('%Y-%m-%d')
@@ -688,6 +682,15 @@ class TestrunSession():
     elif len(profile_json.get('name').strip()) == 0:
       LOGGER.error('Name field left empty')
       return False
+
+    # Check if profile name has special characters
+    for field in ['name', 'rename']:
+      profile_name = profile_json.get(field)
+      if profile_name:
+        for char in profile_name:
+          if char in r"\<>?/:;@''][=^":
+            LOGGER.error('Profile name should not contain special characters')
+            return False
 
     # Error handling if 'questions' not in request
     if 'questions' not in profile_json and valid:

--- a/framework/python/src/core/session.py
+++ b/framework/python/src/core/session.py
@@ -156,7 +156,7 @@ class TestrunSession():
 
   def start(self):
     self.reset()
-    self._status = TestrunStatus.WAITING_FOR_DEVICE
+    self._status = TestrunStatus.STARTING
     self._started = datetime.datetime.now()
 
   def get_started(self):
@@ -603,6 +603,12 @@ class TestrunSession():
     The content has already been validated in the API"""
 
     profile_name = profile_json['name']
+
+    # Check if profile name has special characters
+    for char in profile_name:
+      if char in r"\<>?/:;@''][=^!":
+        LOGGER.error('Profile name should not contain special characters')
+        return None
 
     # Add version, timestamp and status
     profile_json['version'] = self.get_version()

--- a/testing/api/profiles/invalid_name.json
+++ b/testing/api/profiles/invalid_name.json
@@ -1,0 +1,39 @@
+{
+  "name": "<>?/:;@''][=^!",
+  "version": "1.4",
+  "created": "2024-09-03",
+  "questions": [
+    {
+      "question": "How will this device be used at Google?",
+      "answer": "Monitoring"
+    },
+    {
+      "question": "Is this device going to be managed by Google or a third party?",
+      "answer": "Google"
+    },
+    {
+      "question": "Will the third-party device administrator be able to grant access to authorized Google personnel upon request?",
+      "answer": "N/A"
+    },
+    {
+      "question": "Which of the following statements are true about this device?",
+      "answer": [0]
+    },
+    {
+      "question": "Does the network protocol assure server-to-client identity verification?",
+      "answer": "Yes"
+    },
+    {
+      "question": "Click the statements that best describe the characteristics of this device.",
+      "answer": [0]
+    },
+    {
+      "question": "Are any of the following statements true about this device?",
+      "answer": [0]
+    },
+    {
+      "question": "Comments",
+      "answer": ""
+    }
+  ]
+}

--- a/testing/api/test_api.py
+++ b/testing/api/test_api.py
@@ -2901,6 +2901,68 @@ def test_create_profile_invalid_json(empty_profiles_dir, testrun): # pylint: dis
   # Check if "error" key in response
   assert "error" in response
 
+def test_create_profile_invalid_name(empty_profiles_dir, testrun): # pylint: disable=W0613
+  """ Test for create profile invalid name (400) """
+
+  # Load the profile
+  new_profile = load_json("invalid_name.json", directory=PROFILES_PATH)
+
+  # Send the post request
+  r = requests.post(f"{API}/profiles", data=json.dumps(new_profile), timeout=5)
+
+  # Check if status code is 400 (Bad request)
+  assert r.status_code == 400
+
+  # Parse the response
+  response = r.json()
+
+  # Check if "error" key in response
+  assert "error" in response
+
+@pytest.mark.parametrize("add_profiles", [
+  ["valid_profile.json"]
+], indirect=True)
+def test_update_profile_invalid_name(empty_profiles_dir, add_profiles, testrun): # pylint: disable=W0613
+  """ Test for update profile invalid name (400) """
+
+  # Load the profile using load_json utility method
+  new_profile = load_json("valid_profile.json", directory=PROFILES_PATH)
+
+  # Assign the new_profile name
+  profile_name = new_profile["name"]
+
+  # Assign the profile questions
+  profile_questions = new_profile["questions"]
+
+  # Assign the updated_profile name
+  updated_profile_name = r"\<>?/:;@''][=^"
+
+  # Payload with the updated device name
+  updated_profile = {
+    "name": profile_name,
+    "rename" : updated_profile_name,
+    "questions": profile_questions
+    }
+
+  # Exception if the profile does not exists
+  if not profile_exists(profile_name):
+    raise ValueError(f"Profile: {profile_name} does not exists")
+
+  # Send the post request to update the profile
+  r = requests.post(
+      f"{API}/profiles",
+      data=json.dumps(updated_profile),
+      timeout=5)
+
+  # Check if status code is 400 (Bad request)
+  assert r.status_code == 400
+
+  # Parse the response
+  response = r.json()
+
+  # Check if "error" key in response
+  assert "error" in response
+
 @pytest.mark.parametrize("add_profiles", [
   ["valid_profile.json"]
 ], indirect=True)


### PR DESCRIPTION
When profile name contains '/' character it causes a crash.
![error_special_chars](https://github.com/user-attachments/assets/4b7e968f-db47-4383-864a-e3be78eedebf)

Added an error message if the profile name contains any of the following characters: \<>?/:;@''][=^!
![handle_error_profile_name](https://github.com/user-attachments/assets/e3ef6165-7f86-4e76-99e7-22d451139388)

Added 2 tests for create and update profile when profile name is invalid. 
Moved the special characters check into session/validate_profile_json 
