### PR TITLE
Added debug message in case users enters an incorrect device mac address

### DIFF
--- a/framework/python/src/core/testrun.py
+++ b/framework/python/src/core/testrun.py
@@ -463,6 +463,8 @@ class Testrun:  # pylint: disable=too-few-public-methods
 
     if device is not None:
       if mac_addr != device.mac_addr:
+        LOGGER.debug(f'Found device with mac addr: {mac_addr} but was ignored')
+        LOGGER.debug(f'Expected device mac address is {device.mac_addr}')
         # Ignore discovered device because it is not the target device
         return
     else:

--- a/framework/python/src/core/testrun.py
+++ b/framework/python/src/core/testrun.py
@@ -463,8 +463,8 @@ class Testrun:  # pylint: disable=too-few-public-methods
 
     if device is not None:
       if mac_addr != device.mac_addr:
-        LOGGER.debug(f'Found device with mac addr: {mac_addr} but was ignored')
-        LOGGER.debug(f'Expected device mac address is {device.mac_addr}')
+        LOGGER.info(f'Found device with mac addr: {mac_addr} but was ignored')
+        LOGGER.info(f'Expected device mac address is {device.mac_addr}')
         # Ignore discovered device because it is not the target device
         return
     else:


### PR DESCRIPTION
If users enter the incorrect device mac address, debug message will be displayed on terminal during the test with device mac address found but ignored and the expected device mac address.