### PR TITLE
Add full port scan to determine any HTTPS/TLS server running on non-s…

### DIFF
--- a/modules/test/tls/conf/module_config.json
+++ b/modules/test/tls/conf/module_config.json
@@ -9,7 +9,7 @@
     "docker": {
       "depends_on": "base",
       "enable_container": true,
-      "timeout": 420
+      "timeout": 540
     },
     "tests":[
       {

--- a/modules/test/tls/python/requirements.txt
+++ b/modules/test/tls/python/requirements.txt
@@ -18,4 +18,4 @@ pyOpenSSL==24.3.0
 lxml==5.1.0 # Requirement of pyshark but if upgraded automatically above 5.1 will cause a
 pyshark==0.6
 requests==2.32.3
-
+python-nmap==0.7.1

--- a/modules/test/tls/python/src/http_scan.py
+++ b/modules/test/tls/python/src/http_scan.py
@@ -1,0 +1,76 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module that contains various methods for scaning for HTTP/HTTPS services"""
+import nmap
+import socket
+import ssl
+
+LOGGER = None
+
+
+class HTTPScan():
+  """Helper class to scan for all HTTP/HTTPS services for a device"""
+
+  def __init__(self, logger):
+    global LOGGER
+    LOGGER = logger
+
+  def scan_all_ports(self, ip):
+    """Scans all ports and identifies potential HTTP/HTTPS ports."""
+    nm = nmap.PortScanner()
+    nm.scan(hosts=ip, ports='1-65535', arguments='--open -sV')
+
+    http_ports = []
+    for host in nm.all_hosts():
+      for proto in nm[host].all_protocols():
+        for port in nm[host][proto].keys():
+          service = nm[host][proto][port]['name']
+          if 'http' in service:
+            http_ports.append(port)
+    return http_ports
+
+  def is_https(self, ip, port):
+    """Attempts a TLS handshake to determine if the port serves HTTPS."""
+    try:
+      context = ssl.create_default_context()
+      context.check_hostname = False
+      context.verify_mode = ssl.CERT_NONE
+      with socket.create_connection((ip, port), timeout=2) as sock:
+        with context.wrap_socket(sock, server_hostname=ip):
+          return True
+    except ssl.SSLError:
+      return False
+    except Exception:  # pylint: disable=W0718
+      return False
+
+  def verify_http_or_https(self, ip, ports):
+    """Classifies each port as HTTP or HTTPS."""
+    results = {}
+    for port in ports:
+      if self.is_https(ip, port):
+        results[port] = 'HTTPS'
+      else:
+        results[port] = 'HTTP'
+    return results
+
+  def scan_for_http_services(self, ip_address):
+    LOGGER.info(f'Scanning for HTTP ports on {ip_address}')
+    http_ports = self.scan_all_ports(ip_address)
+    results = None
+    if len(http_ports) > 0:
+      LOGGER.info(f'Checking HTTP ports on {ip_address}: {http_ports}')
+      results = self.verify_http_or_https(ip_address, http_ports)
+      for port, service_type in results.items():
+        LOGGER.info(f'Port {port}: {service_type}')
+    return results

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -356,8 +356,8 @@ class TLSModule(TestModule):
     all_packets = []
     # Iterate over each file
     for pcap_file in pcap_files:
-      # Open the capture file
-      packets = pyshark.FileCapture(pcap_file)
+      # Open the capture file and filter by tls
+      packets = pyshark.FileCapture(pcap_file, display_filter='tls')
       try:
         # Iterate over each packet in the file and add it to the list
         for packet in packets:

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -16,6 +16,7 @@
 
 from test_module import TestModule
 from tls_util import TLSUtil
+from http_scan import HTTPScan
 import os
 import pyshark
 from binascii import hexlify
@@ -55,6 +56,8 @@ class TLSModule(TestModule):
     global LOGGER
     LOGGER = self._get_logger()
     self._tls_util = TLSUtil(LOGGER)
+    self._http_scan = HTTPScan(LOGGER)
+    self._scan_results = None
 
   def generate_module_report(self):
     html_content = '<h4 class="page-heading">TLS Module</h4>'
@@ -387,53 +390,102 @@ class TLSModule(TestModule):
 
   def _security_tls_v1_2_server(self):
     LOGGER.info('Running security.tls.v1_2_server')
-    self._resolve_device_ip()
     # If the ipv4 address wasn't resolved yet, try again
+    self._resolve_device_ip()
+    ports_valid = []
+    ports_invalid = []
+    result = None
+    details = ''
+    description = ''
     if self._device_ipv4_addr is not None:
-      tls_1_2_results = self._tls_util.validate_tls_server(
-          self._device_ipv4_addr, tls_version='1.2')
-      tls_1_3_results = self._tls_util.validate_tls_server(
-          self._device_ipv4_addr, tls_version='1.3')
-      results = self._tls_util.process_tls_server_results(
-          tls_1_2_results, tls_1_3_results)
+      if self._scan_results is None:
+        self._scan_results = self._http_scan.scan_for_http_services(
+            self._device_ipv4_addr)
+      if self._scan_results is not None:
+        for port, service_type in self._scan_results.items():
+          if 'HTTPS' in service_type:
+            LOGGER.info(f'Inspecting Service on port {port}: {service_type}')
+            tls_1_2_results = self._tls_util.validate_tls_server(
+                host=self._device_ipv4_addr, port=port, tls_version='1.2')
+            tls_1_3_results = self._tls_util.validate_tls_server(
+                host=self._device_ipv4_addr, port=port, tls_version='1.3')
+            port_results = self._tls_util.process_tls_server_results(
+                tls_1_2_results, tls_1_3_results, port=port)
+            if port_results is not None:
+              result = port_results[
+                  0] if result is None else result and port_results[0]
+              details += port_results[1]
+              if port_results[0]:
+                ports_valid.append(port)
+              else:
+                ports_invalid.append(port)
+          elif 'HTTP' in service_type:
+            # Any non-HTTPS service detetcted is automatically invalid
+            ports_invalid.append(port)
+            details += f'\nHTTP service detected on port {port}'
+            result = False
+        LOGGER.debug(f'Valid Ports: {ports_valid}')
+        LOGGER.debug(f'Invalid Ports: {ports_invalid}')
       # Determine results and return proper messaging and details
-      description = ''
-      result = results[0]
-      details = results[1]
       if result is None:
         result = 'Feature Not Detected'
         description = 'TLS 1.2 certificate could not be validated'
       elif result:
-        description = 'TLS 1.2 certificate is valid'
+        ports_csv = ','.join(map(str,ports_valid))
+        description = f'TLS 1.2 certificate valid on ports: {ports_csv}'
       else:
-        description = 'TLS 1.2 certificate is invalid'
+        ports_csv = ','.join(map(str,ports_invalid))
+        description = f'TLS 1.2 certificate invalid on ports: {ports_csv}'
       return result, description, details
-
     else:
       LOGGER.error('Could not resolve device IP address. Skipping')
       return 'Error', 'Could not resolve device IP address'
 
   def _security_tls_v1_3_server(self):
     LOGGER.info('Running security.tls.v1_3_server')
-    self._resolve_device_ip()
     # If the ipv4 address wasn't resolved yet, try again
+    self._resolve_device_ip()
+    ports_valid = []
+    ports_invalid = []
+    result = None
+    details = ''
+    description = ''
     if self._device_ipv4_addr is not None:
-      results = self._tls_util.validate_tls_server(self._device_ipv4_addr,
-                                                   tls_version='1.3')
+      if self._scan_results is None:
+        self._scan_results = self._http_scan.scan_for_http_services(
+            self._device_ipv4_addr)
+      if self._scan_results is not None:
+        for port, service_type in self._scan_results.items():
+          if 'HTTPS' in service_type:
+            LOGGER.info(f'Inspecting Service on port {port}: {service_type}')
+            port_results = self._tls_util.validate_tls_server(
+                self._device_ipv4_addr, tls_version='1.3', port=port)
+            if port_results is not None:
+              result = port_results[
+                  0] if result is None else result and port_results[0]
+              details += port_results[1]
+              if port_results[0]:
+                ports_valid.append(port)
+              else:
+                ports_invalid.append(port)
+          elif 'HTTP' in service_type:
+            # Any non-HTTPS service detetcted is automatically invalid
+            ports_invalid.append(port)
+            details += f'\nHTTP service detected on port {port}'
+            result = False
+        LOGGER.debug(f'Valid Ports: {ports_valid}')
+        LOGGER.debug(f'Invalid Ports: {ports_invalid}')
       # Determine results and return proper messaging and details
-      description = ''
-      result = results[0]
-      details = results[1]
-      description = ''
       if result is None:
         result = 'Feature Not Detected'
         description = 'TLS 1.3 certificate could not be validated'
-      elif results[0]:
-        description = 'TLS 1.3 certificate is valid'
+      elif result:
+        ports_csv = ','.join(map(str,ports_valid))
+        description = f'TLS 1.3 certificate valid on ports: {ports_csv}'
       else:
-        description = 'TLS 1.3 certificate is invalid'
+        ports_csv = ','.join(map(str,ports_invalid))
+        description = f'TLS 1.3 certificate invalid on ports: {ports_csv}'
       return result, description, details
-
     else:
       LOGGER.error('Could not resolve device IP address')
       return 'Error', 'Could not resolve device IP address'
@@ -472,14 +524,14 @@ class TLSModule(TestModule):
   def _security_tls_v1_2_client(self):
     LOGGER.info('Running security.tls.v1_2_client')
     return self._validate_tls_client(self._device_mac,
-                                      '1.2',
-                                      unsupported_versions=['1.0', '1.1'])
+                                     '1.2',
+                                     unsupported_versions=['1.0', '1.1'])
 
   def _security_tls_v1_3_client(self):
     LOGGER.info('Running security.tls.v1_3_client')
     return self._validate_tls_client(self._device_mac,
-                                      '1.3',
-                                      unsupported_versions=['1.0', '1.1'])
+                                     '1.3',
+                                     unsupported_versions=['1.0', '1.1'])
 
   def _validate_tls_client(self,
                            client_mac,

--- a/testing/unit/tls/tls_module_test.py
+++ b/testing/unit/tls/tls_module_test.py
@@ -71,7 +71,7 @@ class TLSModuleTest(unittest.TestCase):
                                                    tls_version='1.2')
     tls_1_3_results = None, 'No TLS 1.3'
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertTrue(test_results[0])
 
   # Test 1.2 server when 1.3 connection is established
@@ -80,7 +80,7 @@ class TLSModuleTest(unittest.TestCase):
     tls_1_3_results = TLS_UTIL.validate_tls_server('google.com',
                                                    tls_version='1.3')
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertTrue(test_results[0])
 
   # Test 1.2 server when 1.2 and 1.3 connection is established
@@ -90,7 +90,7 @@ class TLSModuleTest(unittest.TestCase):
     tls_1_3_results = TLS_UTIL.validate_tls_server('google.com',
                                                    tls_version='1.3')
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertTrue(test_results[0])
 
   # Test 1.2 server when 1.2 and failed 1.3 connection is established
@@ -99,7 +99,7 @@ class TLSModuleTest(unittest.TestCase):
                                                    tls_version='1.2')
     tls_1_3_results = False, 'Signature faild'
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertTrue(test_results[0])
 
   # Test 1.2 server when 1.3 and failed 1.2 connection is established
@@ -108,10 +108,10 @@ class TLSModuleTest(unittest.TestCase):
                                                    tls_version='1.3')
     tls_1_2_results = False, 'Signature faild'
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertTrue(test_results[0])
 
-  def security_tls_server_results_test(self, ):
+  def security_tls_server_results_test(self):
     # Generic messages to test they are passing through
     # to the results as expected
     fail_message = 'Certificate not validated'
@@ -121,74 +121,75 @@ class TLSModuleTest(unittest.TestCase):
     # Both None
     tls_1_2_results = None, none_message
     tls_1_3_results = None, none_message
-    expected = None, (f'TLS 1.2 not validated: {none_message}\n'
-                      f'TLS 1.3 not validated: {none_message}')
+    expected = None, (f'TLS 1.2 not validated on port 443: {none_message}\n'
+                      f'TLS 1.3 not validated on port 443: {none_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.2 Pass and TLS 1.3 None
     tls_1_2_results = True, success_message
-    expected = True, f'TLS 1.2 validated: {success_message}'
+    expected = True, f'TLS 1.2 validated on port 443: {success_message}'
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.2 Fail and TLS 1.3 None
     tls_1_2_results = False, fail_message
-    expected = False, f'TLS 1.2 not validated: {fail_message}'
+    expected = False, f'TLS 1.2 not validated on port 443: {fail_message}'
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.3 Pass and TLS 1.2 None
     tls_1_2_results = None, fail_message
     tls_1_3_results = True, success_message
-    expected = True, f'TLS 1.3 validated: {success_message}'
+    expected = True, f'TLS 1.3 validated on port 443: {success_message}'
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.3 Fail and TLS 1.2 None
     tls_1_3_results = False, fail_message
-    expected = False, f'TLS 1.3 not validated: {fail_message}'
+    expected = False, f'TLS 1.3 not validated on port 443: {fail_message}'
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.2 Pass and TLS 1.3 Pass
     tls_1_2_results = True, success_message
     tls_1_3_results = True, success_message
-    expected = True, (f'TLS 1.2 validated: {success_message}\n'
-                      f'TLS 1.3 validated: {success_message}')
+    expected = True, (f'TLS 1.2 validated on port 443: {success_message}\n'
+                      f'TLS 1.3 validated on port 443: {success_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
+    
     self.assertEqual(result, expected)
 
     # TLS 1.2 Pass and TLS 1.3 Fail
     tls_1_2_results = True, success_message
     tls_1_3_results = False, fail_message
-    expected = True, (f'TLS 1.2 validated: {success_message}\n'
-                      f'TLS 1.3 not validated: {fail_message}')
+    expected = True, (f'TLS 1.2 validated on port 443: {success_message}\n'
+                      f'TLS 1.3 not validated on port 443: {fail_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.2 Fail and TLS 1.2 Pass
     tls_1_2_results = False, fail_message
     tls_1_3_results = True, success_message
-    expected = True, (f'TLS 1.2 not validated: {fail_message}\n'
-                      f'TLS 1.3 validated: {success_message}')
+    expected = True, (f'TLS 1.2 not validated on port 443: {fail_message}\n'
+                      f'TLS 1.3 validated on port 443: {success_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
     # TLS 1.2 Fail and TLS 1.2 Fail
     tls_1_3_results = False, fail_message
-    expected = False, (f'TLS 1.2 not validated: {fail_message}\n'
-                       f'TLS 1.3 not validated: {fail_message}')
+    expected = False, (f'TLS 1.2 not validated on port 443: {fail_message}\n'
+                       f'TLS 1.3 not validated on port 443: {fail_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                 tls_1_3_results)
+                                                 tls_1_3_results,port=443)
     self.assertEqual(result, expected)
 
   # Test 1.2 server when 1.3 and 1.2 failed connection is established
@@ -196,7 +197,7 @@ class TLSModuleTest(unittest.TestCase):
     tls_1_2_results = False, 'Signature faild'
     tls_1_3_results = False, 'Signature faild'
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertFalse(test_results[0])
 
     # Test 1.2 server when 1.3 and 1.2 failed connection is established
@@ -205,7 +206,7 @@ class TLSModuleTest(unittest.TestCase):
     tls_1_2_results = None, 'No cert'
     tls_1_3_results = None, 'No cert'
     test_results = TLS_UTIL.process_tls_server_results(tls_1_2_results,
-                                                       tls_1_3_results)
+                                                       tls_1_3_results,port=443)
     self.assertIsNone(test_results[0])
 
   def security_tls_v1_3_server_test(self):
@@ -608,7 +609,7 @@ if __name__ == '__main__':
   suite.addTest(TLSModuleTest('security_tls_v1_2_fail_server_test'))
   suite.addTest(TLSModuleTest('security_tls_v1_2_none_server_test'))
 
-  # # TLS 1.3 server tests
+  # TLS 1.3 server tests
   suite.addTest(TLSModuleTest('security_tls_v1_3_server_test'))
 
   # TLS client tests

--- a/testing/unit/tls/tls_module_test.py
+++ b/testing/unit/tls/tls_module_test.py
@@ -163,7 +163,7 @@ class TLSModuleTest(unittest.TestCase):
                       f'TLS 1.3 validated on port 443: {success_message}')
     result = TLS_UTIL.process_tls_server_results(tls_1_2_results,
                                                  tls_1_3_results,port=443)
-    
+
     self.assertEqual(result, expected)
 
     # TLS 1.2 Pass and TLS 1.3 Fail


### PR DESCRIPTION
Add a full port scan when determining if there are any web servers running and validate accordingly.

 - Check for both HTTP and HTTPS services running on all ports
 - Determines which services are HTTP and HTTPS
 - Fails TLS server tests if any HTTP ports are detected
 - Update report to indicate which ports have valid and invalid servers running
 - Increase module timeout by 2 minutes to account for port scan

Current report:
![Screenshot 2025-01-10 130302](https://github.com/user-attachments/assets/b5e3bf1b-d401-4671-ba4a-23b5fc3961ab)

Updated report with HTTP port detected:
![Screenshot 2025-01-10 140104](https://github.com/user-attachments/assets/1f08b459-66cc-41fe-a1d8-815e1f084801)

Updated report with valid web server:
![Screenshot 2025-01-10 152655](https://github.com/user-attachments/assets/21aa1659-5651-4321-8283-c2646a778be4)

Updated report with invalid web server:
![Screenshot 2025-01-10 153104](https://github.com/user-attachments/assets/436777d8-6cd2-4928-aa7b-d39c4a5741fb)
