### PR TITLE
Fix protocol.services.bacnet 

### DIFF
--- a/resources/test_packs/pilot.json
+++ b/resources/test_packs/pilot.json
@@ -146,6 +146,10 @@
         "required_result": "Informational"
       },
       {
+        "name": "protocol.services.bacnet",
+        "required_result": "Informational"
+      },
+      {
         "name": "security.tls.v1_0_client",
         "required_result": "Required if Applicable"
       },

--- a/resources/test_packs/qualification.json
+++ b/resources/test_packs/qualification.json
@@ -155,7 +155,7 @@
         },
         {
           "name": "protocol.services.bacnet",
-          "required_result": "Required"
+          "required_result": "Informational"
         },
         {
           "name": "security.tls.v1_0_client",

--- a/resources/test_packs/qualification.json
+++ b/resources/test_packs/qualification.json
@@ -154,6 +154,10 @@
           "required_result": "Required"
         },
         {
+          "name": "protocol.services.bacnet",
+          "required_result": "Required"
+        },
+        {
           "name": "security.tls.v1_0_client",
           "required_result": "Informational"
         },


### PR DESCRIPTION
Port 47808 was not scanned. Added protocol.services.bacnet  in test_packs. 

Before
![scan_before](https://github.com/user-attachments/assets/43737619-9754-4dc2-9fef-68bc6c5d2214)

After
![protocol services bacnet](https://github.com/user-attachments/assets/55e8b428-0008-4258-8401-553a1cb160ab)
