### PR TITLE
392112885: (feat) [2.1.1 release] rename results modals for Pilot

### DIFF
--- a/resources/test_packs/pilot.json
+++ b/resources/test_packs/pilot.json
@@ -1,8 +1,8 @@
 {
     "name": "Pilot Assessment",
     "language": {
-      "compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendations will be provided by the lab team.",
-      "non_compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendations will be provided by the lab team."
+      "compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendation will be provided by the lab team.",
+      "non_compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendation will be provided by the lab team."
     },
     "tests": [
       {

--- a/resources/test_packs/pilot.json
+++ b/resources/test_packs/pilot.json
@@ -1,8 +1,8 @@
 {
     "name": "Pilot Assessment",
     "language": {
-      "compliant_description": "Your device has met the initial pilot assessment requirements. Please send your Testrun ZIP file to the qualification lab for verification. The lab will then contact you with further instructions.",
-      "non_compliant_description": "Your device didn't quite meet the initial pilot assessment requirements. The Testrun report will provide guidance on how to resolve any issues. If you require further support, please get in touch with the qualification lab."
+      "compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendations will be provided by the lab team.",
+      "non_compliant_description": "This is a preliminary test result. Please attach the Risk Profile and download the test results. A full evaluation and recommendations will be provided by the lab team."
     },
     "tests": [
       {


### PR DESCRIPTION
### Overview
Ticket: 392112885
feat: [2.1.1 release] rename results modals for Pilot - the descriptions for Completed modal with Pilot statuses "Proceed" and "Do Not Proceed" are changed

### Screenshots before changes
https://screenshot.googleplex.com/5Kr79y9p72CE4zz
https://screenshot.googleplex.com/xNvWY8nA5yXkRrz

### Screenshots after changes
https://screenshot.googleplex.com/6XXVEs3eJt9eDCr
https://screenshot.googleplex.com/59AuPtLisdDCPsd