### PR TITLE
fix: change width to the result list name for preventing overlapping

### DIFF
--- a/resources/report/test_report_styles.css
+++ b/resources/report/test_report_styles.css
@@ -457,7 +457,7 @@
       position: absolute;
       font-size: 12px;
       margin-top: 12px;
-      max-width: 300px;
+      max-width: 190px;
       font-weight: normal;
       align-items: center;
       text-overflow: ellipsis;


### PR DESCRIPTION
fix: change width to the result list name for preventing overlapping