### PR TITLE
Fix calculate_result from test_pack

### DIFF
--- a/resources/test_packs/pilot/test_pack.py
+++ b/resources/test_packs/pilot/test_pack.py
@@ -4,9 +4,13 @@ from common.statuses import TestrunStatus, TestrunResult, TestResult
 
 def calculate_result(json):
   """Provide the testing result based on the output of testing"""
+
   result = TestrunResult.COMPLIANT
 
   for test_result in json:
+
+    # Values for 'required_result' from config.json
+    json_result = ["required if applicable", "recommended", "roadmap" ]
 
     # Check Required tests
     if (test_result.required_result.lower() == "required"
@@ -16,18 +20,8 @@ def calculate_result(json):
         ]):
       result = TestrunResult.NON_COMPLIANT
 
-    # Check Required if Applicable tests
-    elif (test_result.required_result.lower() == "required if applicable"
-          and test_result.result == TestResult.NON_COMPLIANT):
-      result = TestrunResult.NON_COMPLIANT
-
-    # Check Recommended tests
-    elif (test_result.required_result.lower() == "recommended"
-          and test_result.result == TestResult.NON_COMPLIANT):
-      result = TestrunResult.NON_COMPLIANT
-
-    # Check Roadmap tests
-    elif (test_result.required_result.lower() == "roadmap"
+    # Check 'Required if Applicable', 'Recommended' and 'Roadmap' tests
+    elif (test_result.required_result.lower() in json_result
           and test_result.result == TestResult.NON_COMPLIANT):
       result = TestrunResult.NON_COMPLIANT
 

--- a/resources/test_packs/pilot/test_pack.py
+++ b/resources/test_packs/pilot/test_pack.py
@@ -21,6 +21,16 @@ def calculate_result(json):
           and test_result.result == TestResult.NON_COMPLIANT):
       result = TestrunResult.NON_COMPLIANT
 
+    # Check Recommended tests
+    elif (test_result.required_result.lower() == "recommended"
+          and test_result.result == TestResult.NON_COMPLIANT):
+      result = TestrunResult.NON_COMPLIANT
+
+    # Check Roadmap tests
+    elif (test_result.required_result.lower() == "roadmap"
+          and test_result.result == TestResult.NON_COMPLIANT):
+      result = TestrunResult.NON_COMPLIANT
+
   return result
 
 def calculate_status(result, json): # pylint: disable=unused-argument

--- a/resources/test_packs/qualification/test_pack.py
+++ b/resources/test_packs/qualification/test_pack.py
@@ -8,6 +8,9 @@ def calculate_result(json):
 
   for test_result in json:
 
+    # Values for 'required_result' from config.json
+    json_result = ["required if applicable", "recommended", "roadmap" ]
+
     # Check Required tests
     if (test_result.required_result.lower() == "required"
         and test_result.result not in [
@@ -16,18 +19,8 @@ def calculate_result(json):
         ]):
       result = TestrunResult.NON_COMPLIANT
 
-    # Check Required if Applicable tests
-    elif (test_result.required_result.lower() == "required if applicable"
-          and test_result.result == TestResult.NON_COMPLIANT):
-      result = TestrunResult.NON_COMPLIANT
-
-    # Check Recommended tests
-    elif (test_result.required_result.lower() == "recommended"
-          and test_result.result == TestResult.NON_COMPLIANT):
-      result = TestrunResult.NON_COMPLIANT
-
-    # Check Roadmap tests
-    elif (test_result.required_result.lower() == "roadmap"
+    # Check 'Required if Applicable', 'Recommended' and 'Roadmap' tests
+    elif (test_result.required_result.lower() in json_result
           and test_result.result == TestResult.NON_COMPLIANT):
       result = TestrunResult.NON_COMPLIANT
 

--- a/resources/test_packs/qualification/test_pack.py
+++ b/resources/test_packs/qualification/test_pack.py
@@ -21,6 +21,16 @@ def calculate_result(json):
           and test_result.result == TestResult.NON_COMPLIANT):
       result = TestrunResult.NON_COMPLIANT
 
+    # Check Recommended tests
+    elif (test_result.required_result.lower() == "recommended"
+          and test_result.result == TestResult.NON_COMPLIANT):
+      result = TestrunResult.NON_COMPLIANT
+
+    # Check Roadmap tests
+    elif (test_result.required_result.lower() == "roadmap"
+          and test_result.result == TestResult.NON_COMPLIANT):
+      result = TestrunResult.NON_COMPLIANT
+
   return result
 
 def calculate_status(result, json): # pylint: disable=unused-argument


### PR DESCRIPTION
calculate_result from test_pack for both Pilot and Qualification is returning Compliant when the test result is Non-Compliant

Before
![pilot_before](https://github.com/user-attachments/assets/bb13fd63-2764-45ba-a3a6-b67f275e84dc)
![logic_error](https://github.com/user-attachments/assets/4aeb8f1d-a1c9-4057-ad8a-21fa6d62e4d7)


After
![pil0t_after](https://github.com/user-attachments/assets/f18a9955-edb9-435e-8c55-c80b15c20a45)
![qual_after](https://github.com/user-attachments/assets/f2a824c6-e746-446a-89ba-59737b1d96b7)
