### PR TITLE
Fix BACnet version test failures

### DIFF
--- a/modules/test/protocol/python/src/protocol_module.py
+++ b/modules/test/protocol/python/src/protocol_module.py
@@ -29,7 +29,7 @@ class ProtocolModule(TestModule):
     super().__init__(module_name=module, log_name=LOG_NAME)
     global LOGGER
     LOGGER = self._get_logger()
-    self._bacnet = BACnet(log=LOGGER,device_hw_addr=self._device_mac)
+    self._bacnet = BACnet(log=LOGGER, device_hw_addr=self._device_mac)
 
   def _protocol_valid_bacnet(self):
     LOGGER.info('Running protocol.valid_bacnet')
@@ -70,13 +70,11 @@ class ProtocolModule(TestModule):
 
     if len(self._bacnet.devices) > 0:
       for device in self._bacnet.devices:
-        if self._device_ipv4_addr in device[2]:
-          LOGGER.debug(f'Checking BACnet version for device: {device}')
-          result_status, result_description = \
-            self._bacnet.validate_protocol_version(device[2], device[3])
-          break
-        else:
-          LOGGER.debug('Device does not match expected IP address, skipping')
+        LOGGER.debug(f'Checking BACnet version for device: {device}')
+        result_status, result_description = \
+          self._bacnet.validate_protocol_version(self._device_ipv4_addr,
+            device[3])
+        break
 
     LOGGER.info(result_description)
     return result_status, result_description


### PR DESCRIPTION
Some devices do not respond with their IP address as part of their BACnet discovery response, generally these are virtual devices causing this test to be skipped and report incorrect results.  This removes the IP check from the BACnet version test as this is already accounted for in the BACnet validation step and directly attempts to read the version based on device ip and object id found in the discovery process.