### PR TITLE
No packets found in protocol.pcap

### DIFF
--- a/modules/test/protocol/python/src/protocol_bacnet.py
+++ b/modules/test/protocol/python/src/protocol_bacnet.py
@@ -122,6 +122,9 @@ class BACnet():
       capture_file = os.path.join(self._captures_dir, self._capture_file)
       packets = self.get_bacnet_packets(capture_file, object_id)
       valid = None
+      # If no packets are found in protocol.pcap
+      if not packets:
+        LOGGER.debug(f'No BACnet packets found for object id {object_id}')
       for packet in packets:
         if object_id in packet['_source']['layers']['bacapp.instance_number']:
           if device_hw_addr.lower() in packet['_source']['layers']['eth.src']:


### PR DESCRIPTION
Add a message when no BACnet packets are found in protocol.pcap