### PR TITLE
A11y: The Refresh link on the general settings page is not accessible  by keyboard

### DIFF
--- a/modules/ui/src/app/pages/general-settings/general-settings.component.html
+++ b/modules/ui/src/app/pages/general-settings/general-settings.component.html
@@ -196,7 +196,7 @@ limitations under the License.
         (keydown.enter)="reloadSetting()"
         (keydown.space)="reloadSetting()"
         role="button"
-        [tabindex]="1"
+        [tabindex]="0"
         class="message-link">
         Refresh
       </a>


### PR DESCRIPTION
Change tabindex

http://screencast/cast/NjIzNjUxMDYxMjM1NzEyMHxkNzRhYTRjOS01NQ