### PR TITLE
A11y: The Aria attribute doesn't match the role

### DIFF
--- a/modules/ui/src/app/components/side-button-menu/side-button-menu.component.html
+++ b/modules/ui/src/app/components/side-button-menu/side-button-menu.component.html
@@ -7,6 +7,7 @@
     <mat-icon>add</mat-icon>
   </button>
   <div
+    aria-hidden="true"
     class="side-add-menu-trigger"
     #menuTrigger="matMenuTrigger"
     [matMenuTriggerFor]="menu"></div>


### PR DESCRIPTION
Hide non-interactive element

![4XkvrDyQZcMfe5u](https://github.com/user-attachments/assets/665d200d-7f87-4c3c-9735-f37d1c1337e6)
