### PR TITLE
407737058: (fix) hide help tip when the actions menu opens

### DIFF
--- a/modules/ui/src/styles.scss
+++ b/modules/ui/src/styles.scss
@@ -372,6 +372,12 @@ body:has(.filter-dialog-content)
   .cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
   opacity: 0;
 }
+// Hide the help tip when the actions menu opens
+body:has(.side-add-menu-backdrop.cdk-overlay-backdrop-showing) {
+  app-help-tip {
+    display: none;
+  }
+}
 
 body #main {
   &:has(.device-repository-content-empty),


### PR DESCRIPTION
### Overview
Ticket: 407737058
fix: hide help tip when the actions menu opens

### Video after changes
https://screencast.googleplex.com/cast/NTgzODM1MjEyNDIxNTI5NnwzN2ViZWIxOC04OA