### PR TITLE
Screen reader: The button is not announced after clicking the Download button  on the Testing page

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/download-options/download-options.component.html
+++ b/modules/ui/src/app/pages/testrun/components/download-options/download-options.component.html
@@ -44,7 +44,9 @@ limitations under the License.
     class="download-button"
     [class.download-button-opened]="isOpenDownloadOptions"
     color="primary"
-    aria-label="Download options"
+    [attr.aria-label]="
+      isOpenDownloadOptions ? 'Hide download options' : 'Show download options'
+    "
     mat-flat-button>
     <mat-icon
       *ngIf="!isOpenDownloadOptions"


### PR DESCRIPTION
Change label for download button

Video after changes (sound on)
http://screencast/cast/NTY5MDk2MDEyMDkwNTcyOHw4ZTMwMWJmNi0zYQ