### PR TITLE
Zoom in: the texts on the risk assessment page are overlapped

### DIFF
--- a/modules/ui/src/app/components/dynamic-form/dynamic-form.component.html
+++ b/modules/ui/src/app/components/dynamic-form/dynamic-form.component.html
@@ -125,7 +125,9 @@ limitations under the License.
       matInput
       id="{{ formControlName }}-group"
       [formControlName]="formControlName" />
-    <mat-hint *ngIf="description">{{ description }}</mat-hint>
+    <mat-hint *ngIf="description" class="field-hint">{{
+      description
+    }}</mat-hint>
     <mat-error
       *ngIf="getControl(formControlName).hasError('invalid_format')"
       role="alert"
@@ -159,7 +161,9 @@ limitations under the License.
       cdkTextareaAutosize
       id="{{ formControlName }}-group"
       [formControlName]="formControlName"></textarea>
-    <mat-hint *ngIf="description">{{ description }}</mat-hint>
+    <mat-hint *ngIf="description" class="field-hint">{{
+      description
+    }}</mat-hint>
     <mat-error
       *ngIf="getControl(formControlName).hasError('invalid_format')"
       role="alert"
@@ -192,7 +196,9 @@ limitations under the License.
       matInput
       id="{{ formControlName }}-group"
       [formControlName]="formControlName" />
-    <mat-hint *ngIf="description">{{ description }}</mat-hint>
+    <mat-hint *ngIf="description" class="field-hint">{{
+      description
+    }}</mat-hint>
     <mat-error *ngIf="getControl(formControlName).hasError('required')">
       <span>The field is required</span>
     </mat-error>

--- a/modules/ui/src/app/components/dynamic-form/dynamic-form.component.scss
+++ b/modules/ui/src/app/components/dynamic-form/dynamic-form.component.scss
@@ -41,7 +41,6 @@ mat-form-field {
   font-weight: 400;
   line-height: 16px;
   text-align: left;
-  padding-top: 8px;
 }
 
 .form-field {

--- a/modules/ui/src/app/components/dynamic-form/dynamic-form.component.spec.ts
+++ b/modules/ui/src/app/components/dynamic-form/dynamic-form.component.spec.ts
@@ -236,4 +236,15 @@ describe('DynamicFormComponent', () => {
       });
     }
   });
+
+  describe('adjustSubscriptWrapperHeights', () => {
+    it('should set height for hint wrapper', () => {
+      component.adjustSubscriptWrapperHeights();
+
+      const wrapper = compiled.querySelector(
+        '.mat-mdc-form-field-subscript-wrapper'
+      );
+      expect(wrapper?.clientHeight).toEqual(20);
+    });
+  });
 });

--- a/modules/ui/src/app/components/dynamic-form/dynamic-form.component.ts
+++ b/modules/ui/src/app/components/dynamic-form/dynamic-form.component.ts
@@ -15,9 +15,12 @@
  */
 import {
   Component,
+  HostListener,
   inject,
   Input,
   OnInit,
+  Renderer2,
+  viewChildren,
   ViewEncapsulation,
 } from '@angular/core';
 import {
@@ -48,7 +51,6 @@ import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { TextFieldModule } from '@angular/cdk/text-field';
-import { DeviceValidators } from '../../pages/devices/components/device-form/device.validators';
 import { ProfileValidators } from '../../pages/risk-assessment/profile-form/profile.validators';
 import { DomSanitizer } from '@angular/platform-browser';
 @Component({
@@ -78,15 +80,21 @@ import { DomSanitizer } from '@angular/platform-browser';
   encapsulation: ViewEncapsulation.None,
 })
 export class DynamicFormComponent implements OnInit {
+  readonly formFields = viewChildren(MatFormField);
+
   private fb = inject(FormBuilder);
-  private deviceValidators = inject(DeviceValidators);
   private profileValidators = inject(ProfileValidators);
   private domSanitizer = inject(DomSanitizer);
+  private renderer = inject(Renderer2);
 
   public readonly FormControlType = FormControlType;
 
   @Input() format: QuestionFormat[] = [];
   @Input() optionKey: string | undefined;
+  @HostListener('window:resize')
+  onResize() {
+    this.adjustSubscriptWrapperHeights();
+  }
 
   parentContainer = inject(ControlContainer);
   get formGroup() {
@@ -180,5 +188,26 @@ export class DynamicFormComponent implements OnInit {
     return this.domSanitizer.bypassSecurityTrustHtml(
       this.getOptionValue(option)
     );
+  }
+
+  private adjustSubscriptWrapperHeights(): void {
+    this.formFields().forEach(formField => {
+      const matFormField = formField._elementRef.nativeElement;
+      if (matFormField) {
+        const subscriptWrapper = matFormField.querySelector(
+          '.mat-mdc-form-field-subscript-wrapper'
+        ) as HTMLElement;
+        const hint = matFormField.querySelector(
+          '.mat-mdc-form-field-hint'
+        ) as HTMLElement;
+        if (subscriptWrapper && hint) {
+          this.renderer.setStyle(
+            subscriptWrapper,
+            'height',
+            `${hint.offsetHeight}px`
+          );
+        }
+      }
+    });
   }
 }

--- a/modules/ui/src/app/components/dynamic-form/dynamic-form.component.ts
+++ b/modules/ui/src/app/components/dynamic-form/dynamic-form.component.ts
@@ -190,7 +190,7 @@ export class DynamicFormComponent implements OnInit {
     );
   }
 
-  private adjustSubscriptWrapperHeights(): void {
+  adjustSubscriptWrapperHeights(): void {
     this.formFields().forEach(formField => {
       const matFormField = formField._elementRef.nativeElement;
       if (matFormField) {


### PR DESCRIPTION
The team of angular material recommends to use one-line hints, so for this case it's better to use approach with script as css changes can break whole component

Video after changes
http://screencast/cast/NjM1NTUwNDI5MTkwNTUzNnwyMDE3NGNmOC0zMg