### PR TITLE
Remove 'any kind of IP multicast' from mdns test

### DIFF
--- a/modules/test/dns/README.md
+++ b/modules/test/dns/README.md
@@ -16,4 +16,4 @@ Within the ```python/src``` directory, the below tests are executed.
 |---|---|---|---|
 | dns.network.hostname_resolution | Verifies that the device resolves hostnames | The device sends DNS requests | Required |
 | dns.network.from_dhcp | Verifies that the device allows for a DNS server to be provided by the DHCP server | The device sends DNS requests to the DNS server provided by the DHCP server | Informational |
-| dns.mdns | Does the device has MDNS (or any kind of IP multicast) | Device may send MDNS requests | Informational |
+| dns.mdns | Does the device has MDNS | Device may send MDNS requests | Informational |

--- a/modules/ui/src/app/mocks/testrun.mock.ts
+++ b/modules/ui/src/app/mocks/testrun.mock.ts
@@ -39,7 +39,7 @@ export const TEST_DATA_RESULT: IResult[] = [
   },
   {
     name: 'dns.mdns',
-    description: 'Does the device has MDNS (or any kind of IP multicast)',
+    description: 'Does the device has MDNS',
     result: 'Not Started',
     required_result: RequiredResult.RequiredIfApplicable,
   },
@@ -75,7 +75,7 @@ export const TEST_DATA_RESULT_WITH_ERROR: IResult[] = [
   },
   {
     name: 'dns.mdns',
-    description: 'Does the device has MDNS (or any kind of IP multicast)',
+    description: 'Does the device has MDNS ',
     result: 'Not Started',
     required_result: RequiredResult.Required,
   },


### PR DESCRIPTION
Removed "Any kind of IP multicast" from mdns test