### PR TITLE
The issue with the alignment of the description row

### DIFF
--- a/modules/ui/src/app/pages/testrun/components/testrun-table/testrun-table.component.scss
+++ b/modules/ui/src/app/pages/testrun/components/testrun-table/testrun-table.component.scss
@@ -61,6 +61,7 @@ mat-header-cell {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: center;
 
   p {
     margin: 0;


### PR DESCRIPTION
Align the details by center
Before 
![image](https://github.com/user-attachments/assets/f9d0af74-e313-49fc-8756-2395ac425d67)
After
![image](https://github.com/user-attachments/assets/2d15d849-beda-45cc-bbd4-82c3e7832fcd)
