### PR TITLE
The unsaved risk profile is shown twice while navigating from the copied one to any other.

### DIFF
--- a/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.ts
+++ b/modules/ui/src/app/pages/risk-assessment/risk-assessment.component.ts
@@ -277,8 +277,10 @@ export class RiskAssessmentComponent
     this.cd.markForCheck();
   }
   setCopy(copyOfProfile: Profile, profiles: Profile[]) {
-    this.store.updateProfiles([copyOfProfile, ...profiles]);
-    this.cd.detectChanges();
+    if (profiles.every(profile => profile !== copyOfProfile)) {
+      this.store.updateProfiles([copyOfProfile, ...profiles]);
+      this.cd.detectChanges();
+    }
   }
 
   actions(actions: EntityAction[]) {


### PR DESCRIPTION
Do not insert copy when the same copy already exist

Screenshot before
https://screenshot.googleplex.com/7PEJniZguoVERwb

Video after changes
http://screencast/cast/NjQwODYxMzA4NTA1MjkyOHw3MGI5YTc1Mi03MQ