### PR TITLE
A11y: The hover tooltip is not implemented for the devices and risk profile tiles

### DIFF
--- a/modules/ui/src/app/components/device-item/device-item.component.html
+++ b/modules/ui/src/app/components/device-item/device-item.component.html
@@ -41,6 +41,7 @@ limitations under the License.
     [tabIndex]="tabIndex"
     (click)="itemClick()"
     attr.aria-label="Edit device {{ label }}"
+    matTooltip="Edit device"
     class="device-item button-edit"
     type="button">
     <ng-container

--- a/modules/ui/src/app/components/list-item/list-item.component.ts
+++ b/modules/ui/src/app/components/list-item/list-item.component.ts
@@ -28,7 +28,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { CommonModule } from '@angular/common';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { EntityAction } from '../../model/entity-action';
-import { MatTooltip } from '@angular/material/tooltip';
+import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-list-item',
@@ -39,6 +39,8 @@ import { MatTooltip } from '@angular/material/tooltip';
     MatMenu,
     MatMenuItem,
     CommonModule,
+    MatTooltipModule,
+    MatTooltip,
   ],
   providers: [MatTooltip],
   templateUrl: './list-item.component.html',


### PR DESCRIPTION
Fix tooltips

Screenshots after changes
https://screenshot.googleplex.com/5cMvYWS9wauxC7r
https://screenshot.googleplex.com/7DoDQX3eRKW5bjD
