### PR TITLE
docs: fix typo DEGUG → DEBUG in log level example

### DIFF
--- a/docs/additional_config.md
+++ b/docs/additional_config.md
@@ -78,7 +78,7 @@ set the log_level property for:
     ```
     "test_modules":{
         "connection":{
-          "log_level": "DEGUG"
+          "log_level": "DEBUG"
         }
       }
       ```


### PR DESCRIPTION

## Description
This PR fixes a small typo in the documentation.

- **File:** `docs/additional_config.md`  
- **Section:** *Override test module log level at the system level*  
- **Change:** `"DEGUG"` → `"DEBUG"`  

## Why
Correct spelling of the log level ensures consistency with valid logging levels and avoids confusion for users following the example.

Related Issue
Closes #1343
