### PR TITLE
[TR] The Steps to resolve text is not available for some Non-Compliant tests on the Connection module

### DIFF
--- a/make/DEBIAN/control
+++ b/make/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Testrun
-Version: 2.3.1-beta.4
+Version: 2.3.1-beta.5
 Architecture: amd64
 Maintainer: Google <ssm-orcas@google.com>
 Homepage: https://github.com/google/testrun

--- a/modules/test/conn/conf/module_config.json
+++ b/modules/test/conn/conf/module_config.json
@@ -16,17 +16,27 @@
       {
         "name": "connection.port_link",
         "test_description": "The network switch port connected to the device has an active link without errors",
-        "expected_behavior": "When the ethernet cable is connected to the port, the device triggers the port to its enabled \"Link UP\" (LEDs illuminate on device and switch ports if present) state, and the switch shows no errors with the LEDs and when interrogated with a \"show interface\" command on most network switches."
+        "expected_behavior": "When the ethernet cable is connected to the port, the device triggers the port to its enabled \"Link UP\" (LEDs illuminate on device and switch ports if present) state, and the switch shows no errors with the LEDs and when interrogated with a \"show interface\" command on most network switches.",
+        "recommendations": [
+          "Check the physical connection and integrity of the Ethernet cable",
+          "Verify that the switch port is in an up state"
+        ]
       },
       {
         "name": "connection.port_speed",
         "test_description": "The network switch port connected to the device has auto-negotiated a speed that is 10 Mbps or higher",
-        "expected_behavior": "When the ethernet cable is connected to the port, the device autonegotiates a speed that can be checked with the \"show interface\" command on most network switches.  The output of this command must also show that the \"configured speed\" is set to \"auto\"."
+        "expected_behavior": "When the ethernet cable is connected to the port, the device autonegotiates a speed that can be checked with the \"show interface\" command on most network switches.  The output of this command must also show that the \"configured speed\" is set to \"auto\".",
+        "recommendations": [
+          "Ensure Auto-negotiation is enabled on both the device and the switch port"
+        ]
       },
       {
         "name": "connection.port_duplex",
         "test_description": "The network switch port connected to the device has auto-negotiated full-duplex",
-        "expected_behavior": "When the ethernet cable is connected to the port, the device autonegotiates a full-duplex connection."
+        "expected_behavior": "When the ethernet cable is connected to the port, the device autonegotiates a full-duplex connection.",
+        "recommendations": [
+          "Ensure Auto-negotiation is enabled on both the device and the switch port"
+        ]
       },
       {
         "name": "connection.switch.arp_inspection",
@@ -52,7 +62,11 @@
       {
         "name": "connection.switch.dhcp_snooping",
         "test_description": "The device operates as a DHCP client and operates correctly when DHCP snooping is enabled on a switch.",
-        "expected_behavior": "Device continues to operate correctly when DHCP snooping is enabled on the switch."
+        "expected_behavior": "Device continues to operate correctly when DHCP snooping is enabled on the switch.",
+        "recommendations": [
+          "Verify that the switch port is correctly configured as 'untrusted' for the client",
+          "Ensure the DHCP server is connected to a 'trusted' port on the switch"
+        ]
       },
       {
         "name": "connection.dhcp_address",
@@ -126,12 +140,21 @@
       {
         "name": "connection.dhcp_disconnect",
         "test_description": "The device under test issues a new DHCPREQUEST packet after a port physical disconnection and reconnection",
-        "expected_behavior": "A client SHOULD use DHCP to reacquire or verify its IP address and network parameters whenever the local network parameters may have changed; e.g., at system boot time or after a disconnection from the local network, as the local network configuration may change without the client's or user's knowledge. If a client has knowledge ofa  previous network address and is unable to contact a local DHCP server, the client may continue to use the previous network address until the lease for that address expires.  If the lease expires before the client can contact a DHCP server, the client must immediately discontinue use of the previous network address and may inform local users of the problem."
+        "expected_behavior": "A client SHOULD use DHCP to reacquire or verify its IP address and network parameters whenever the local network parameters may have changed; e.g., at system boot time or after a disconnection from the local network, as the local network configuration may change without the client's or user's knowledge. If a client has knowledge ofa  previous network address and is unable to contact a local DHCP server, the client may continue to use the previous network address until the lease for that address expires.  If the lease expires before the client can contact a DHCP server, the client must immediately discontinue use of the previous network address and may inform local users of the problem.",
+        "recommendations": [
+          "Verify that the device's network stack correctly detects the Link Down/Link Up events",
+          "Check if the device OS/firmware is configured to renew DHCP on link state change"
+        ]
       },
       {
         "name": "connection.dhcp_disconnect_ip_change",
         "test_description": "When device is disconnected,  update device IP on the DHCP server and reconnect the device.  Ensure device received new IP address",
-        "expected_behavior": "If IP address for a device was changed on the DHCP server while the device was disconnected then the device should request and update the new IP upon reconnecting to the network"
+        "expected_behavior": "If IP address for a device was changed on the DHCP server while the device was disconnected then the device should request and update the new IP upon reconnecting to the network",
+        "recommendations": [
+          "Ensure the device does not ignore DHCPNAK messages from the server",
+          "Verify the device's DHCP client behavior when the 'Requested IP' is no longer available",
+          "Check if the device is caching old IP parameters longer than the Lease Time allows"
+        ]
       },
       {
         "name": "connection.single_ip",

--- a/modules/test/dns/conf/module_config.json
+++ b/modules/test/dns/conf/module_config.json
@@ -33,7 +33,12 @@
       {
         "name": "dns.mdns",
         "test_description": "Does the device have MDNS (or any kind of IP multicast)",
-        "expected_behavior": "Device may send MDNS requests"
+        "expected_behavior": "Device may send MDNS requests",
+        "recommendations": [
+          "Enable mDNS support in the device network configuration",
+          "Check if the network switch has IGMP Snooping enabled, which might block multicast",
+          "Ensure the device is on a network segment that allows multicast traffic"
+        ]
       }
     ]
   }

--- a/modules/test/protocol/conf/module_config.json
+++ b/modules/test/protocol/conf/module_config.json
@@ -16,12 +16,21 @@
       {
         "name": "protocol.valid_bacnet",
         "test_description": "Can valid BACnet traffic be seen",
-        "expected_behavior": "BACnet traffic can be seen on the network and packets are valid and not malformed"
+        "expected_behavior": "BACnet traffic can be seen on the network and packets are valid and not malformed",
+        "recommendations": [
+          "Inspect network traffic for malformed packets or checksum errors",
+          "Verify that the MTU settings are consistent across the network path"
+        ]
       },
       {
         "name": "protocol.bacnet.version",
         "test_description": "Obtain the version of BACnet client used",
-        "expected_behavior": "The BACnet client implements an up to date version of BACnet"
+        "expected_behavior": "The BACnet client implements an up to date version of BACnet",
+        "recommendations": [
+          "Update the device firmware",
+          "Inspect network traffic for malformed packets or checksum errors",
+          "Ensure the device supports the required ASHRAE 135 protocol revision"
+        ]
       },
       {
         "name": "protocol.valid_modbus",

--- a/modules/test/services/conf/module_config.json
+++ b/modules/test/services/conf/module_config.json
@@ -377,6 +377,12 @@
         "name": "protocol.services.bacnet",
         "test_description": "Report whether the device is running a BACnet server",
         "expected_behavior": "The device may or may not be running a BACnet server",
+        "recommendations": [
+          "Verify if the BACnet service is enabled in the device settings",
+          "Check if UDP port 47808 is open and not blocked by a firewall",
+          "Ensure the BACnet stack is properly initialized on the device",
+          "Ensure the BACnet service is running on the same network interface to which the device under test is connected"
+        ],
         "config": {
           "services": [
             "bacnet"


### PR DESCRIPTION
Adds missing steps to resolve