### PR TITLE
[TR] A11y: Clear purpose: The link"here" is used on the Welcome modal

### DIFF
--- a/modules/ui/src/app/components/version/consent-dialog/consent-dialog.component.html
+++ b/modules/ui/src/app/components/version/consent-dialog/consent-dialog.component.html
@@ -85,13 +85,12 @@ limitations under the License.
     <app-callout [type]="CalloutType.Info">
       Testrun uses Google Analytics to learn about how our users use the
       application. By installing and running Testrun, you understand and accept
-      the Terms of Service found
+      the
       <a
         href="https://policies.google.com/technologies/partner-sites"
         target="_blank"
         class="message-link"
-        aria-label="here on Google Privacy & Terms page"
-        >here</a
+        >Google Terms of Service</a
       >.
     </app-callout>
   </section>


### PR DESCRIPTION
Improve "here" link