### PR TITLE
[TR] A11y: Accessible name: The hover with the button name is not shown  for Delete button on the Certificates page

### DIFF
--- a/make/DEBIAN/control
+++ b/make/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Testrun
-Version: 2.3.2
+Version: 2.3.1-beta.8
 Architecture: amd64
 Maintainer: Google <ssm-orcas@google.com>
 Homepage: https://github.com/google/testrun

--- a/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.html
+++ b/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.html
@@ -76,6 +76,7 @@ limitations under the License.
           [disabled]="data.uploading"
           class="certificate-item-delete"
           mat-icon-button
+          matTooltip="Delete {{ data.name }} certificate"
           attr.aria-label="Delete {{ data.name }} certificate"
           (click)="deleteButtonClicked.emit(data.name)">
           <mat-icon fontSet="material-symbols-outlined"> delete </mat-icon>

--- a/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.ts
+++ b/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.ts
@@ -7,6 +7,7 @@ import { CommonModule } from '@angular/common';
 import { CalloutType } from '../../../../model/callout-type';
 import { CalloutComponent } from '../../../../components/callout/callout.component';
 import { EmptyMessageComponent } from '../../../../components/empty-message/empty-message.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-certificates-table',
@@ -17,6 +18,7 @@ import { EmptyMessageComponent } from '../../../../components/empty-message/empt
     CommonModule,
     CalloutComponent,
     EmptyMessageComponent,
+    MatTooltipModule,
   ],
   templateUrl: './certificates-table.component.html',
   styleUrl: './certificates-table.component.scss',


### PR DESCRIPTION
Adds tooltip to delete certificate