### PR TITLE
[TR] A11y: Accessible names: the Clear search button doesn't have the hover

### DIFF
--- a/make/DEBIAN/control
+++ b/make/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Testrun
-Version: 2.3.2
+Version: 2.3.1-beta.9
 Architecture: amd64
 Maintainer: Google <ssm-orcas@google.com>
 Homepage: https://github.com/google/testrun

--- a/modules/ui/src/app/components/list-layout/list-layout.component.html
+++ b/modules/ui/src/app/components/list-layout/list-layout.component.html
@@ -47,6 +47,7 @@ limitations under the License.
                 (click)="clearSearch()"
                 class="clear-search-button"
                 mat-icon-button
+                matTooltip="Clear search"
                 aria-label="Clear search">
                 <mat-icon>close</mat-icon>
               </button>

--- a/modules/ui/src/app/components/list-layout/list-layout.component.ts
+++ b/modules/ui/src/app/components/list-layout/list-layout.component.ts
@@ -33,6 +33,7 @@ import { EntityAction, EntityActionResult } from '../../model/entity-action';
 import { Device } from '../../model/device';
 import { LayoutType } from '../../model/layout-type';
 import { Profile } from '../../model/profile';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
   selector: 'app-list-layout',
@@ -43,6 +44,7 @@ import { Profile } from '../../model/profile';
     MatToolbarModule,
     MatIconModule,
     ListItemComponent,
+    MatTooltipModule,
   ],
   providers: [DatePipe],
   templateUrl: './list-layout.component.html',


### PR DESCRIPTION
Adds tooltip to clear search button