### PR TITLE
[TR] A11y: Focus: the focus is moved to the first interactive element in the content instead of moving back to the initial button

### DIFF
--- a/modules/ui/src/app/app.component.html
+++ b/modules/ui/src/app/app.component.html
@@ -260,7 +260,7 @@ limitations under the License.
         [data]="HelpTips.step3"
         [target]="testingTipTarget"
         (onCLoseTip)="onCLoseTip($event)"
-        (onAction)="navigateToRuntime()">
+        (onAction)="startTestrun(true)">
       </app-help-tip>
     }
     @if (

--- a/modules/ui/src/app/app.component.spec.ts
+++ b/modules/ui/src/app/app.component.spec.ts
@@ -52,7 +52,6 @@ import {
   selectInterfaces,
   selectInternetConnection,
   selectIsAllDevicesOutdated,
-  selectIsOpenStartTestrun,
   selectIsOpenWaitSnackBar,
   selectIsTestingComplete,
   selectReports,
@@ -114,7 +113,6 @@ describe('AppComponent', () => {
       'getSystemStatus',
       'systemStatus$',
       'isTestrunStarted$',
-      'setIsOpenStartTestrun',
       'fetchDevices',
       'getTestModules',
       'testrunInProgress',
@@ -176,7 +174,6 @@ describe('AppComponent', () => {
             { selector: selectSystemStatus, value: null },
             { selector: selectIsTestingComplete, value: false },
             { selector: selectRiskProfiles, value: [] },
-            { selector: selectIsOpenStartTestrun, value: false },
             { selector: selectIsOpenWaitSnackBar, value: false },
             { selector: selectReports, value: [] },
           ],
@@ -506,6 +503,7 @@ describe('AppComponent', () => {
 
       keyboardCases.forEach(testCase => {
         it(`should navigate to the testing on keydown ${testCase.name} "Start Testrun" link`, fakeAsync(() => {
+          const openTestrun = spyOn(component, 'startTestrun');
           const helpTipLinkEl = compiled.querySelector(
             '.tip-action-link'
           ) as HTMLAnchorElement;
@@ -513,7 +511,7 @@ describe('AppComponent', () => {
           helpTipLinkEl.dispatchEvent(testCase.event);
           flush();
 
-          expect(router.url).toBe(Routes.Testing);
+          expect(openTestrun).toHaveBeenCalled();
         }));
       });
 

--- a/modules/ui/src/app/app.component.ts
+++ b/modules/ui/src/app/app.component.ts
@@ -167,9 +167,8 @@ export class AppComponent implements AfterViewInit {
     }
   }
 
-  navigateToRuntime = () => {
-    this.route.navigate([Routes.Testing]);
-    this.appStore.setIsOpenStartTestrun();
+  startTestrun = (focusFirstElementOnPage?: boolean) => {
+    this.appStore.startTestrun(focusFirstElementOnPage);
   };
 
   navigateToAddDevice = () => {
@@ -187,7 +186,7 @@ export class AppComponent implements AfterViewInit {
       svgIcon: 'testrun_logo_small',
       label: 'Start Testing',
       description: 'Configure your testing tasks',
-      onClick: this.navigateToRuntime,
+      onClick: this.startTestrun,
       disabled$: this.appStore.testrunButtonDisabled$,
     },
     {

--- a/modules/ui/src/app/app.store.ts
+++ b/modules/ui/src/app/app.store.ts
@@ -31,6 +31,7 @@ import {
   selectStatus,
   selectSystemConfig,
   selectSystemStatus,
+  selectTestModules,
 } from './store/selectors';
 import { Store } from '@ngrx/store';
 import { AppState } from './store/state';
@@ -42,11 +43,11 @@ import {
   filter,
   Observable,
   skip,
+  takeUntil,
 } from 'rxjs';
 import { Device, TestingType, TestModule } from './model/device';
 import {
   setDevices,
-  setIsOpenStartTestrun,
   fetchSystemStatus,
   fetchRiskProfiles,
   fetchReports,
@@ -67,6 +68,9 @@ import { TestRunMqttService } from './services/test-run-mqtt.service';
 import { NotificationService } from './services/notification.service';
 import { Profile } from './model/profile';
 import { map } from 'rxjs/internal/operators/map';
+import { TestrunDialogService } from './services/testrun-dialog.service';
+import { Routes } from './model/routes';
+import { Router } from '@angular/router';
 
 export const CONSENT_SHOWN_KEY = 'CONSENT_SHOWN';
 export const CALLOUT_STATE_KEY = 'CALLOUT_STATE';
@@ -84,6 +88,8 @@ export class AppStore extends ComponentStore<AppComponentState> {
   private testRunMqttService = inject(TestRunMqttService);
   private focusManagerService = inject(FocusManagerService);
   private notificationService = inject(NotificationService);
+  private readonly testRunDialogService = inject(TestrunDialogService);
+  private readonly route = inject(Router);
 
   private consentShown$ = this.select(state => state.consentShown);
   private calloutState$ = this.select(state => state.calloutState);
@@ -110,6 +116,7 @@ export class AppStore extends ComponentStore<AppComponentState> {
     selectIsTestingComplete
   );
   riskProfiles$: Observable<Profile[]> = this.store.select(selectRiskProfiles);
+  testModules$ = this.store.select(selectTestModules);
 
   testrunButtonDisabled$ = combineLatest([
     this.hasDevices$,
@@ -252,12 +259,25 @@ export class AppStore extends ComponentStore<AppComponentState> {
     );
   }
 
-  setIsOpenStartTestrun = this.effect(trigger$ => {
-    return trigger$.pipe(
-      tap(() => {
-        this.store.dispatch(
-          setIsOpenStartTestrun({ isOpenStartTestrun: true })
-        );
+  startTestrun = this.effect<boolean | undefined>(trigger$ => {
+    return combineLatest([trigger$, this.testModules$]).pipe(
+      tap(([focusFirstElementOnPage, testModules]) => {
+        this.testRunDialogService
+          .openInitiateDialog({ testModules })
+          .pipe(takeUntil(this.destroy$))
+          .subscribe(status => {
+            if (status) {
+              this.route.navigate([Routes.Testing]).then(() => {
+                if (focusFirstElementOnPage) {
+                  this.testRunDialogService.handleFocus();
+                } else {
+                  this.focusManagerService.focusFirstElementInContainer(
+                    window.document.querySelector('.side-add-button-container')
+                  );
+                }
+              });
+            }
+          });
       })
     );
   });

--- a/modules/ui/src/app/guards/can-activate.guard.spec.ts
+++ b/modules/ui/src/app/guards/can-activate.guard.spec.ts
@@ -39,7 +39,6 @@ describe('CanActivateGuard', () => {
     hasRiskProfiles: false,
     isStopTestrun: false,
     isOpenWaitSnackBar: false,
-    isOpenStartTestrun: false,
     systemStatus: null,
     deviceInProgress: null,
     status: null,

--- a/modules/ui/src/app/pages/devices/devices.component.spec.ts
+++ b/modules/ui/src/app/pages/devices/devices.component.spec.ts
@@ -252,13 +252,34 @@ describe('DevicesComponent', () => {
         tick(100);
 
         expect(router.url).toBe(Routes.Testing);
-        expect(mockDevicesStore.setStatus).toHaveBeenCalledWith(
-          MOCK_PROGRESS_DATA_IN_PROGRESS
-        );
         expect(testRunDialogServiceMock.handleFocus).toHaveBeenCalled();
 
         testRunDialogServiceMock.openInitiateDialog.calls.reset();
       });
+    }));
+  });
+
+  describe('#menuItemClicked', () => {
+    it('should show device item for StartNewTestrun action', fakeAsync(() => {
+      const spyOpenDialog = spyOn(component, 'openStartTestrun');
+      component.menuItemClicked(
+        { action: DeviceAction.StartNewTestrun, entity: device, index: 1 },
+        [],
+        []
+      );
+
+      expect(spyOpenDialog).toHaveBeenCalled();
+    }));
+
+    it('should show device item for Delete action', fakeAsync(() => {
+      const spyOpenDialog = spyOn(component, 'openDeleteDialog');
+      component.menuItemClicked(
+        { action: DeviceAction.Delete, entity: device, index: 1 },
+        [],
+        []
+      );
+
+      expect(spyOpenDialog).toHaveBeenCalled();
     }));
   });
 });

--- a/modules/ui/src/app/pages/devices/devices.component.ts
+++ b/modules/ui/src/app/pages/devices/devices.component.ts
@@ -146,7 +146,6 @@ export class DevicesComponent
       .pipe(takeUntil(this.destroy$))
       .subscribe(status => {
         if (status) {
-          this.devicesStore.setStatus(status);
           this.route.navigate([Routes.Testing]).then(() => {
             this.testRunDialogService.handleFocus(100);
           });

--- a/modules/ui/src/app/pages/reports/reports.component.spec.ts
+++ b/modules/ui/src/app/pages/reports/reports.component.spec.ts
@@ -1,5 +1,4 @@
-/*
-/!**
+/**
  * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *!/
+ */
 import {
   ComponentFixture,
   fakeAsync,
@@ -31,7 +30,6 @@ import { FilterDialogComponent } from './components/filter-dialog/filter-dialog.
 import { ElementRef } from '@angular/core';
 import { FilterName, FilterTitle } from '../../model/filters';
 import SpyObj = jasmine.SpyObj;
-import { MatSort } from '@angular/material/sort';
 import { DATA_SOURCE_INITIAL_VALUE, ReportsStore } from './reports.store';
 import {
   DATA_SOURCE_FOR_EMPTY_FILTERS,
@@ -117,25 +115,11 @@ describe('ReportsComponent', () => {
     });
 
     describe('ngOnInit', () => {
-      it('should update sort', fakeAsync(() => {
-        const sort = new MatSort();
-        component.sort = sort;
-        component.ngOnInit();
-
-        expect(mockReportsStore.updateSort).toHaveBeenCalledWith(sort);
-      }));
-
       it('should get reports', fakeAsync(() => {
         component.ngOnInit();
 
         expect(mockReportsStore.getReports).toHaveBeenCalled();
       }));
-    });
-
-    it('#sortData should call update sort', () => {
-      component.sortData({ active: '', direction: 'desc' });
-
-      expect(mockReportsStore.updateSort).toHaveBeenCalled();
     });
 
     it('#sortData should call liveAnnouncer with sorted direction message', () => {
@@ -174,6 +158,7 @@ describe('ReportsComponent', () => {
       const event = {
         currentTarget: null,
         stopPropagation: () => undefined,
+        preventDefault: () => undefined,
       } as Event;
       const openSpy = spyOn(component.dialog, 'open').and.returnValue({
         afterClosed: () => of(true),
@@ -208,6 +193,7 @@ describe('ReportsComponent', () => {
       const event = {
         currentTarget: null,
         stopPropagation: () => undefined,
+        preventDefault: () => undefined,
       } as Event;
 
       const mockFilterResults = ['compliant'];
@@ -341,7 +327,7 @@ describe('ReportsComponent', () => {
       });
 
       it('should have empty message', () => {
-        const empty = compiled.querySelector('.results-content-empty');
+        const empty = compiled.querySelector('.history-content-empty');
         expect(empty).toBeTruthy();
       });
     });
@@ -423,4 +409,3 @@ describe('ReportsComponent', () => {
     });
   });
 });
-*/

--- a/modules/ui/src/app/pages/testrun/components/testrun-initiate-form/testrun-initiate-form.component.spec.ts
+++ b/modules/ui/src/app/pages/testrun/components/testrun-initiate-form/testrun-initiate-form.component.spec.ts
@@ -53,7 +53,6 @@ describe('ProgressInitiateFormComponent', () => {
     'systemStatus$',
     'getSystemStatus',
     'fetchVersion',
-    'setIsOpenStartTestrun',
   ]);
   testRunServiceMock.getDevices.and.returnValue(
     new BehaviorSubject<Device[] | null>([device, device])

--- a/modules/ui/src/app/pages/testrun/testrun.component.spec.ts
+++ b/modules/ui/src/app/pages/testrun/testrun.component.spec.ts
@@ -49,17 +49,13 @@ import {
   selectHasDevices,
   selectHasRiskProfiles,
   selectIsAllDevicesOutdated,
-  selectIsOpenStartTestrun,
   selectIsOpenWaitSnackBar,
   selectRiskProfiles,
   selectSystemStatus,
   selectTestModules,
 } from '../../store/selectors';
 import { TestrunStore } from './testrun.store';
-import {
-  fetchSystemStatusSuccess,
-  setTestrunStatus,
-} from '../../store/actions';
+import { setTestrunStatus } from '../../store/actions';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NotificationService } from '../../services/notification.service';
 import { Profile } from '../../model/profile';
@@ -127,7 +123,6 @@ describe('TestrunComponent', () => {
             selectors: [
               { selector: selectHasDevices, value: false },
               { selector: selectIsAllDevicesOutdated, value: false },
-              { selector: selectIsOpenStartTestrun, value: false },
               { selector: selectIsOpenWaitSnackBar, value: false },
               { selector: selectHasRiskProfiles, value: false },
               { selector: selectRiskProfiles, value: [] },
@@ -191,22 +186,6 @@ describe('TestrunComponent', () => {
       expect(component).toBeTruthy();
     });
 
-    describe('openTestRunModal on first flow', () => {
-      beforeEach(() => {
-        testRunDialogServiceMock.openInitiateDialog.and.returnValue(
-          of(MOCK_PROGRESS_DATA_IN_PROGRESS)
-        );
-        store.overrideSelector(selectIsOpenStartTestrun, true);
-        component.ngOnInit();
-      });
-
-      it('should open the modal if isOpenStartTestrun$ as true', () => {
-        component.ngOnInit();
-
-        expect(testRunDialogServiceMock.openInitiateDialog).toHaveBeenCalled();
-      });
-    });
-
     describe('#stopTestrun', () => {
       it('should update system status to Cancelling', () => {
         store.overrideSelector(
@@ -257,7 +236,6 @@ describe('TestrunComponent', () => {
               { selector: selectDevices, value: [] },
               { selector: selectHasDevices, value: false },
               { selector: selectIsAllDevicesOutdated, value: false },
-              { selector: selectIsOpenStartTestrun, value: false },
               { selector: selectIsOpenWaitSnackBar, value: false },
               { selector: selectHasRiskProfiles, value: false },
               { selector: selectRiskProfiles, value: [] },
@@ -387,12 +365,9 @@ describe('TestrunComponent', () => {
         startBtn.click();
 
         expect(testRunDialogServiceMock.openInitiateDialog).toHaveBeenCalled();
-        expect(store.dispatch).toHaveBeenCalledWith(
-          fetchSystemStatusSuccess({
-            systemStatus: MOCK_PROGRESS_DATA_IN_PROGRESS,
-          })
-        );
+
         tick(1000);
+
         expect(testRunDialogServiceMock.handleFocus).toHaveBeenCalled();
 
         testRunDialogServiceMock.openInitiateDialog.calls.reset();

--- a/modules/ui/src/app/pages/testrun/testrun.component.ts
+++ b/modules/ui/src/app/pages/testrun/testrun.component.ts
@@ -17,7 +17,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   OnDestroy,
-  OnInit,
   inject,
 } from '@angular/core';
 import {
@@ -34,7 +33,6 @@ import { FocusManagerService } from '../../services/focus-manager.service';
 import { TestrunStore } from './testrun.store';
 import { TestRunService } from '../../services/test-run.service';
 import { TestModule } from '../../model/device';
-import { combineLatest } from 'rxjs/internal/observable/combineLatest';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -77,7 +75,7 @@ import { TestrunDialogService } from '../../services/testrun-dialog.service';
     TestrunStore,
   ],
 })
-export class TestrunComponent implements OnInit, OnDestroy {
+export class TestrunComponent implements OnDestroy {
   private readonly testRunDialogService = inject(TestrunDialogService);
   private readonly testRunService = inject(TestRunService);
   dialog = inject(MatDialog);
@@ -87,19 +85,6 @@ export class TestrunComponent implements OnInit, OnDestroy {
   public readonly StatusOfTestrun = StatusOfTestrun;
   private destroy$: Subject<boolean> = new Subject<boolean>();
   viewModel$ = this.testrunStore.viewModel$;
-
-  ngOnInit(): void {
-    combineLatest([
-      this.testrunStore.isOpenStartTestrun$,
-      this.testrunStore.testModules$,
-    ])
-      .pipe(takeUntil(this.destroy$))
-      .subscribe(([isOpenStartTestrun, testModules]) => {
-        if (isOpenStartTestrun) {
-          this.openTestRunModal(testModules);
-        }
-      });
-  }
 
   isTestrunInProgress(status?: string) {
     return this.testRunService.testrunInProgress(status);
@@ -165,11 +150,7 @@ export class TestrunComponent implements OnInit, OnDestroy {
     this.testRunDialogService
       .openInitiateDialog({ testModules })
       .pipe(takeUntil(this.destroy$))
-      .subscribe(status => {
-        if (status) {
-          this.testrunStore.setStatus(status);
-        }
-        this.testrunStore.setIsOpenStartTestrun(false);
+      .subscribe(() => {
         this.testRunDialogService.handleFocus(1000);
       });
   }

--- a/modules/ui/src/app/pages/testrun/testrun.store.spec.ts
+++ b/modules/ui/src/app/pages/testrun/testrun.store.spec.ts
@@ -21,7 +21,6 @@ import {
   selectHasConnectionSettings,
   selectHasDevices,
   selectIsAllDevicesOutdated,
-  selectIsOpenStartTestrun,
   selectRiskProfiles,
   selectSystemStatus,
   selectTestModules,
@@ -29,7 +28,6 @@ import {
 import {
   fetchSystemStatus,
   fetchSystemStatusSuccess,
-  setIsOpenStartTestrun,
   setIsStopTestrun,
   setTestrunStatus,
 } from '../../store/actions';
@@ -68,7 +66,6 @@ describe('TestrunStore', () => {
             { selector: selectIsAllDevicesOutdated, value: false },
             { selector: selectSystemStatus, value: null },
             { selector: selectHasConnectionSettings, value: true },
-            { selector: selectIsOpenStartTestrun, value: false },
             { selector: selectRiskProfiles, value: [] },
             { selector: selectTestModules, value: [] },
           ],
@@ -251,16 +248,6 @@ describe('TestrunStore', () => {
         testrunStore.stopTestrun();
 
         expect(store.dispatch).toHaveBeenCalledWith(setIsStopTestrun());
-      });
-    });
-
-    describe('setIsOpenStartTestrun', () => {
-      it('should dispatch action setIsOpenStartTestrun', () => {
-        testrunStore.setIsOpenStartTestrun(true);
-
-        expect(store.dispatch).toHaveBeenCalledWith(
-          setIsOpenStartTestrun({ isOpenStartTestrun: true })
-        );
       });
     });
 

--- a/modules/ui/src/app/pages/testrun/testrun.store.ts
+++ b/modules/ui/src/app/pages/testrun/testrun.store.ts
@@ -22,7 +22,6 @@ import { Store } from '@ngrx/store';
 import {
   selectHasDevices,
   selectIsAllDevicesOutdated,
-  selectIsOpenStartTestrun,
   selectRiskProfiles,
   selectSystemStatus,
   selectTestModules,
@@ -30,7 +29,6 @@ import {
 import {
   fetchSystemStatus,
   fetchSystemStatusSuccess,
-  setIsOpenStartTestrun,
   setIsStopTestrun,
   setTestrunStatus,
 } from '../../store/actions';
@@ -61,7 +59,6 @@ export class TestrunStore extends ComponentStore<TestrunComponentState> {
   private isAllDevicesOutdated$ = this.store.select(selectIsAllDevicesOutdated);
   private profiles$ = this.store.select(selectRiskProfiles);
   private systemStatus$ = this.store.select(selectSystemStatus);
-  isOpenStartTestrun$ = this.store.select(selectIsOpenStartTestrun);
   testModules$ = this.store.select(selectTestModules);
 
   viewModel$ = this.select({
@@ -133,14 +130,6 @@ export class TestrunStore extends ComponentStore<TestrunComponentState> {
     return trigger$.pipe(
       tap(() => {
         this.store.dispatch(setIsStopTestrun());
-      })
-    );
-  });
-
-  setIsOpenStartTestrun = this.effect<boolean>(trigger$ => {
-    return trigger$.pipe(
-      tap(isOpenStartTestrun => {
-        this.store.dispatch(setIsOpenStartTestrun({ isOpenStartTestrun }));
       })
     );
   });

--- a/modules/ui/src/app/services/testrun-dialog.service.spec.ts
+++ b/modules/ui/src/app/services/testrun-dialog.service.spec.ts
@@ -7,11 +7,15 @@ import { of } from 'rxjs';
 import { MOCK_PROGRESS_DATA_IN_PROGRESS } from '../mocks/testrun.mock';
 import { TestrunInitiateFormComponent } from '../pages/testrun/components/testrun-initiate-form/testrun-initiate-form.component';
 import { device, MOCK_TEST_MODULES } from '../mocks/device.mock';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { AppState } from '../store/state';
+import { fetchSystemStatusSuccess } from '../store/actions';
 
 describe('TestrunDialogService', () => {
   let service: TestrunDialogService;
   const stateServiceMock: jasmine.SpyObj<FocusManagerService> =
     jasmine.createSpyObj('stateServiceMock', ['focusFirstElementInContainer']);
+  let store: MockStore<AppState>;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -21,9 +25,12 @@ describe('TestrunDialogService', () => {
           provide: MatDialogRef,
           useValue: {},
         },
+        provideMockStore({}),
       ],
     });
     service = TestBed.inject(TestrunDialogService);
+    store = TestBed.inject(MockStore);
+    spyOn(store, 'dispatch').and.callThrough();
   });
 
   it('should be created', () => {
@@ -36,11 +43,13 @@ describe('TestrunDialogService', () => {
         afterClosed: () => of(MOCK_PROGRESS_DATA_IN_PROGRESS),
       } as MatDialogRef<typeof TestrunInitiateFormComponent>);
 
-      service.openInitiateDialog({
-        testModules: MOCK_TEST_MODULES,
-        device: device,
-        devices: [device],
-      });
+      service
+        .openInitiateDialog({
+          testModules: MOCK_TEST_MODULES,
+          device: device,
+          devices: [device],
+        })
+        .subscribe();
 
       expect(openSpy).toHaveBeenCalledWith(TestrunInitiateFormComponent, {
         ariaLabel: 'Start new testrun',
@@ -54,6 +63,12 @@ describe('TestrunDialogService', () => {
         disableClose: true,
         panelClass: 'initiate-test-run-dialog',
       });
+
+      expect(store.dispatch).toHaveBeenCalledWith(
+        fetchSystemStatusSuccess({
+          systemStatus: MOCK_PROGRESS_DATA_IN_PROGRESS,
+        })
+      );
 
       openSpy.calls.reset();
     }));

--- a/modules/ui/src/app/services/testrun-dialog.service.ts
+++ b/modules/ui/src/app/services/testrun-dialog.service.ts
@@ -7,6 +7,9 @@ import { Observable } from 'rxjs/internal/Observable';
 import { tap } from 'rxjs/operators';
 import { timer } from 'rxjs';
 import { Device, TestModule } from '../model/device';
+import { Store } from '@ngrx/store';
+import { AppState } from '../store/state';
+import { fetchSystemStatusSuccess } from '../store/actions';
 
 export interface TestrunData {
   testModules: TestModule[];
@@ -16,6 +19,7 @@ export interface TestrunData {
 
 @Injectable({ providedIn: 'root' })
 export class TestrunDialogService {
+  private store = inject<Store<AppState>>(Store);
   dialog = inject(MatDialog);
   focusManagerService = inject(FocusManagerService);
 
@@ -35,6 +39,7 @@ export class TestrunDialogService {
       tap(status => {
         if (status) {
           this.sendAnalytics();
+          this.setStatus(status);
         }
       })
     );
@@ -49,5 +54,13 @@ export class TestrunDialogService {
   private sendAnalytics(): void {
     // @ts-expect-error data layer is not null
     window.dataLayer?.push({ event: 'successful_testrun_initiation' });
+  }
+
+  setStatus(systemStatus: TestrunStatus) {
+    this.store.dispatch(
+      fetchSystemStatusSuccess({
+        systemStatus,
+      })
+    );
   }
 }

--- a/modules/ui/src/app/store/actions.ts
+++ b/modules/ui/src/app/store/actions.ts
@@ -90,11 +90,6 @@ export const setTestrunStatus = createAction(
   props<{ systemStatus: TestrunStatus }>()
 );
 
-export const setIsOpenStartTestrun = createAction(
-  '[Shared] Set Is Open Start Testrun',
-  props<{ isOpenStartTestrun: boolean }>()
-);
-
 export const setDeviceInProgress = createAction(
   '[Shared] Set Device In Progress',
   props<{ device: Device | null }>()

--- a/modules/ui/src/app/store/reducers.spec.ts
+++ b/modules/ui/src/app/store/reducers.spec.ts
@@ -26,7 +26,6 @@ import {
   setHasRiskProfiles,
   setIsAllDevicesOutdated,
   setIsOpenAddDevice,
-  setIsOpenStartTestrun,
   setIsOpenWaitSnackBar,
   setIsTestingComplete,
   setReports,
@@ -226,18 +225,6 @@ describe('Reducer', () => {
         ...initialState,
         ...{ isTestingComplete: true },
       };
-
-      expect(state).toEqual(newState);
-      expect(state).not.toBe(initialState);
-    });
-  });
-
-  describe('setIsOpenStartTestrun action', () => {
-    it('should update state', () => {
-      const initialState = initialAppState;
-      const action = setIsOpenStartTestrun({ isOpenStartTestrun: true });
-      const state = fromReducer.sharedReducer(initialState, action);
-      const newState = { ...initialState, ...{ isOpenStartTestrun: true } };
 
       expect(state).toEqual(newState);
       expect(state).not.toBe(initialState);

--- a/modules/ui/src/app/store/reducers.ts
+++ b/modules/ui/src/app/store/reducers.ts
@@ -87,12 +87,6 @@ export const sharedReducer = createReducer(
       isTestingComplete,
     };
   }),
-  on(Actions.setIsOpenStartTestrun, (state, { isOpenStartTestrun }) => {
-    return {
-      ...state,
-      isOpenStartTestrun,
-    };
-  }),
   on(Actions.setDeviceInProgress, (state, { device }) => {
     return {
       ...state,

--- a/modules/ui/src/app/store/selectors.spec.ts
+++ b/modules/ui/src/app/store/selectors.spec.ts
@@ -23,7 +23,6 @@ import {
   selectHasDevices,
   selectHasRiskProfiles,
   selectIsOpenAddDevice,
-  selectIsOpenStartTestrun,
   selectIsOpenWaitSnackBar,
   selectReports,
   selectRiskProfiles,
@@ -50,7 +49,6 @@ describe('Selectors', () => {
     hasRiskProfiles: false,
     isStopTestrun: false,
     isOpenWaitSnackBar: false,
-    isOpenStartTestrun: false,
     systemStatus: null,
     deviceInProgress: null,
     status: null,
@@ -116,11 +114,6 @@ describe('Selectors', () => {
 
   it('should select isTestingComplete', () => {
     const result = selectIsTestingComplete.projector(initialState);
-    expect(result).toEqual(false);
-  });
-
-  it('should select isOpenStartTestrun', () => {
-    const result = selectIsOpenStartTestrun.projector(initialState);
     expect(result).toEqual(false);
   });
 

--- a/modules/ui/src/app/store/selectors.ts
+++ b/modules/ui/src/app/store/selectors.ts
@@ -88,11 +88,6 @@ export const selectIsOpenWaitSnackBar = createSelector(
   (state: AppState) => state.isOpenWaitSnackBar
 );
 
-export const selectIsOpenStartTestrun = createSelector(
-  selectAppState,
-  (state: AppState) => state.isOpenStartTestrun
-);
-
 export const selectStatus = createSelector(
   selectAppState,
   (state: AppState) => state.status

--- a/modules/ui/src/app/store/state.ts
+++ b/modules/ui/src/app/store/state.ts
@@ -39,7 +39,6 @@ export interface AppState {
   // app, devices
   isOpenAddDevice: boolean;
   // app, testrun
-  isOpenStartTestrun: boolean;
   isStopTestrun: boolean;
   isOpenWaitSnackBar: boolean;
   deviceInProgress: Device | null;
@@ -62,7 +61,6 @@ export const initialState: AppState = {
   deviceInProgress: null,
   riskProfiles: [],
   hasRiskProfiles: false,
-  isOpenStartTestrun: false,
   systemStatus: null,
   isTestingComplete: false,
   status: null,


### PR DESCRIPTION
Adds improvements for better a11y; return focus on previous element when the modal is closed