### PR TITLE
[TR] A11y: Accessible names: the focus with the button name is not shown for filtering and sorting options on the Report page

### DIFF
--- a/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.html
+++ b/modules/ui/src/app/pages/certificates/components/certificates-table/certificates-table.component.html
@@ -34,13 +34,6 @@ limitations under the License.
         mat-sort-header
         sortActionDescription="Sort by duration time">
         Organisation
-        <svg
-          matSortHeaderIcon
-          matTooltip="Sort by Organisation"
-          viewBox="0 -960 960 960">
-          <path
-            d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-        </svg>
       </th>
       <td *matCellDef="let data" class="text-nowrap" mat-cell>
         {{ data.organisation }}
@@ -53,13 +46,6 @@ limitations under the License.
         mat-sort-header
         sortActionDescription="Sort by duration time">
         Expires
-        <svg
-          matSortHeaderIcon
-          matTooltip="Sort by Expires"
-          viewBox="0 -960 960 960">
-          <path
-            d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-        </svg>
       </th>
       <td *matCellDef="let data" class="text-nowrap" mat-cell>
         {{ data.expires | date: 'dd MMM yyyy' }}
@@ -72,13 +58,6 @@ limitations under the License.
         mat-sort-header
         sortActionDescription="Sort by duration time">
         Status
-        <svg
-          matSortHeaderIcon
-          matTooltip="Sort by Status"
-          viewBox="0 -960 960 960">
-          <path
-            d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-        </svg>
       </th>
       <td *matCellDef="let data" class="text-nowrap" mat-cell>
         <span [ngClass]="data.status?.toLowerCase()" class="cell-result">

--- a/modules/ui/src/app/pages/reports/components/filter-header/filter-header.component.html
+++ b/modules/ui/src/app/pages/reports/components/filter-header/filter-header.component.html
@@ -1,6 +1,8 @@
 <th
   mat-header-cell
   mat-sort-header
+  matTooltip="Sort by {{ headerText }}"
+  [matTooltipDisabled]="isFilterHovered"
   [sortActionDescription]="sortActionDescription">
   <span>{{ headerText }}</span>
   <ng-container
@@ -14,13 +16,6 @@
       }
     ">
   </ng-container>
-  <svg
-    matSortHeaderIcon
-    matTooltip="Sort by {{ headerText }}"
-    viewBox="0 -960 960 960">
-    <path
-      d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-  </svg>
 </th>
 
 <ng-template
@@ -33,6 +28,10 @@
     (click)="openFilter($event, name, title, filterOpened)"
     (keydown.enter)="openFilter($event, name, title, filterOpened)"
     (keydown.space)="openFilter($event, name, title, filterOpened)"
+    (focus)="isFilterHovered = true"
+    (mouseenter)="isFilterHovered = true"
+    (mouseleave)="isFilterHovered = false"
+    (blur)="isFilterHovered = false"
     class="filter-button filter-button-{{ name }}"
     [ngClass]="
       (filterOpened && activeFilter === name) || filtered ? 'active' : ''

--- a/modules/ui/src/app/pages/reports/components/filter-header/filter-header.component.ts
+++ b/modules/ui/src/app/pages/reports/components/filter-header/filter-header.component.ts
@@ -36,6 +36,7 @@ export class FilterHeaderComponent {
   @Input({ required: true }) activeFilter!: string;
   @Input() sortActionDescription: string = '';
   @Input({ required: true }) headerText!: string;
+  isFilterHovered = false;
 
   openFilter(
     event: Event,

--- a/modules/ui/src/app/pages/reports/reports.component.html
+++ b/modules/ui/src/app/pages/reports/reports.component.html
@@ -56,15 +56,9 @@ limitations under the License.
             *matHeaderCellDef
             mat-header-cell
             mat-sort-header
+            matTooltip="Sort by Duration"
             sortActionDescription="Sort by duration time">
             Duration
-            <svg
-              matSortHeaderIcon
-              matTooltip="Sort by Duration"
-              viewBox="0 -960 960 960">
-              <path
-                d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-            </svg>
           </th>
           <td *matCellDef="let data" class="text-nowrap" mat-cell>
             {{ data.duration }}
@@ -106,15 +100,9 @@ limitations under the License.
             *matHeaderCellDef
             mat-header-cell
             mat-sort-header
+            matTooltip="Sort by assessment type"
             sortActionDescription="Sort by assessment type">
             Assessment type
-            <svg
-              matSortHeaderIcon
-              matTooltip="Sort by assessment type"
-              viewBox="0 -960 960 960">
-              <path
-                d="M440-240v-368L296-464l-56-56 240-240 240 240-56 56-144-144v368h-80Z"></path>
-            </svg>
           </th>
           <td *matCellDef="let data" mat-cell>
             {{ data.program }}


### PR DESCRIPTION
Adds header sorting tooltip