### PR TITLE
[TR] A11y: Focus: the focus is moved to the first interactive element in the content instead of moving back to the initial button

### DIFF
--- a/make/DEBIAN/control
+++ b/make/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: Testrun
-Version: 2.3.1-beta.9
+Version: 2.3.1-beta.10
 Architecture: amd64
 Maintainer: Google <ssm-orcas@google.com>
 Homepage: https://github.com/google/testrun

--- a/modules/ui/src/app/app.store.ts
+++ b/modules/ui/src/app/app.store.ts
@@ -261,26 +261,34 @@ export class AppStore extends ComponentStore<AppComponentState> {
 
   startTestrun = this.effect<boolean | undefined>(trigger$ => {
     return combineLatest([trigger$, this.testModules$]).pipe(
-      tap(([focusFirstElementOnPage, testModules]) => {
+      tap(([focusTip, testModules]) => {
         this.testRunDialogService
           .openInitiateDialog({ testModules })
           .pipe(takeUntil(this.destroy$))
           .subscribe(status => {
             if (status) {
               this.route.navigate([Routes.Testing]).then(() => {
-                if (focusFirstElementOnPage) {
-                  this.testRunDialogService.handleFocus();
-                } else {
-                  this.focusManagerService.focusFirstElementInContainer(
-                    window.document.querySelector('.side-add-button-container')
-                  );
-                }
+                this.setFocusAfterTestrun(focusTip);
               });
+            } else {
+              this.setFocusAfterTestrun(focusTip);
             }
           });
       })
     );
   });
+
+  private setFocusAfterTestrun(focusTip: boolean | undefined) {
+    if (focusTip) {
+      this.focusManagerService.focusFirstElementInContainer(
+        window.document.querySelector('.tip-action-container')
+      );
+    } else {
+      this.focusManagerService.focusFirstElementInContainer(
+        window.document.querySelector('.side-add-button-container')
+      );
+    }
+  }
 
   setFocusOnPage = this.effect<Document | Element | null | undefined>(
     trigger$ => {

--- a/modules/ui/src/app/services/testrun-dialog.service.spec.ts
+++ b/modules/ui/src/app/services/testrun-dialog.service.spec.ts
@@ -58,7 +58,7 @@ describe('TestrunDialogService', () => {
           device: device,
           testModules: MOCK_TEST_MODULES,
         },
-        autoFocus: 'dialog',
+        autoFocus: 'first-tabbable',
         hasBackdrop: true,
         disableClose: true,
         panelClass: 'initiate-test-run-dialog',

--- a/modules/ui/src/app/services/testrun-dialog.service.ts
+++ b/modules/ui/src/app/services/testrun-dialog.service.ts
@@ -29,7 +29,7 @@ export class TestrunDialogService {
     const dialogRef = this.dialog.open(TestrunInitiateFormComponent, {
       ariaLabel: 'Start new testrun',
       data,
-      autoFocus: 'dialog',
+      autoFocus: 'first-tabbable',
       hasBackdrop: true,
       disableClose: true,
       panelClass: 'initiate-test-run-dialog',


### PR DESCRIPTION
Focus after closing the testrun