### PR TITLE
TLS test text should be updated in case nothing was detected

### DIFF
--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -469,7 +469,7 @@ class TLSModule(TestModule):
           if 'HTTPS' in service_type:
             LOGGER.info(f'Inspecting Service on port {port}: {service_type}')
             tls_1_3_results = self._tls_util.validate_tls_server(
-                self._device_ipv4_addr, tls_version='1.3', port=port)
+                host=self._device_ipv4_addr, port=port, tls_version='1.3')
             if tls_1_3_results[0] is not None:
               if result is None:
                 result = tls_1_3_results[0]

--- a/modules/test/tls/python/src/tls_module.py
+++ b/modules/test/tls/python/src/tls_module.py
@@ -437,8 +437,8 @@ class TLSModule(TestModule):
       # Determine results and return proper messaging and details
       if result is None:
         result = 'Feature Not Detected'
-        description = 'TLS 1.2 certificate could not be validated'
-        details.append('TLS 1.2 certificate could not be validated.')
+        description = 'No outbound TLS connections detected'
+        details.append('No outbound TLS connections detected.')
       elif result:
         ports_csv = ','.join(map(str,ports_valid))
         description = f'TLS 1.2 certificate valid on ports: {ports_csv}'
@@ -468,13 +468,21 @@ class TLSModule(TestModule):
         for port, service_type in self._scan_results.items():
           if 'HTTPS' in service_type:
             LOGGER.info(f'Inspecting Service on port {port}: {service_type}')
-            port_results = self._tls_util.validate_tls_server(
+            tls_1_3_results = self._tls_util.validate_tls_server(
                 self._device_ipv4_addr, tls_version='1.3', port=port)
-            if port_results is not None:
-              result = port_results[
-                  0] if result is None else result and port_results[0]
-              details.extend(port_results[1])
-              if port_results[0]:
+            if tls_1_3_results[0] is not None:
+              if result is None:
+                result = tls_1_3_results[0]
+              else:
+                result = result and tls_1_3_results[0]
+              status_str = '' if tls_1_3_results[0] else 'not '
+              details.append(
+                  f'TLS 1.3 {status_str}validated on port {port}:')
+              if isinstance(tls_1_3_results[1], list):
+                details.extend(tls_1_3_results[1])
+              else:
+                details.append(tls_1_3_results[1])
+              if tls_1_3_results[0]:
                 ports_valid.append(port)
               else:
                 ports_invalid.append(port)
@@ -488,7 +496,8 @@ class TLSModule(TestModule):
       # Determine results and return proper messaging and details
       if result is None:
         result = 'Feature Not Detected'
-        description = 'TLS 1.3 certificate could not be validated'
+        description = 'No outbound TLS connections detected'
+        details.append('No outbound TLS connections detected.')
       elif result:
         ports_csv = ','.join(map(str,ports_valid))
         description = f'TLS 1.3 certificate valid on ports: {ports_csv}'

--- a/testing/unit/tls/tls_module_test.py
+++ b/testing/unit/tls/tls_module_test.py
@@ -504,7 +504,11 @@ class TLSModuleTest(unittest.TestCase):
       if tls_version == '1.3':
         return (None, ['Failed to resolve public certificate'])
       elif tls_version == '1.2':
-        return (True, ['Time range valid', 'Public key valid', 'Signature valid'])
+        return (True, [
+            'Time range valid',
+            'Public key valid',
+            'Signature valid',
+        ])
 
     mock_validate_tls_server.side_effect = validate_side_effect
     result, description, details = self.tls_module._security_tls_v1_3_server() # pylint: disable=W0212

--- a/testing/unit/tls/tls_module_test.py
+++ b/testing/unit/tls/tls_module_test.py
@@ -97,8 +97,8 @@ class TLSModuleTest(unittest.TestCase):
     result, description, details = self.tls_module._security_tls_v1_2_server() # pylint: disable=W0212
 
     self.assertEqual(result, 'Feature Not Detected')
-    self.assertEqual(description, 'TLS 1.2 certificate could not be validated')
-    self.assertEqual(details, ['TLS 1.2 certificate could not be validated.'])
+    self.assertEqual(description, 'No outbound TLS connections detected')
+    self.assertEqual(details, ['No outbound TLS connections detected.'])
 
   def security_tls_v1_2_server_scan_failure_test(self):
     """Tests _security_tls_v1_2_server when scan fails"""
@@ -108,8 +108,8 @@ class TLSModuleTest(unittest.TestCase):
     result, description, details = self.tls_module._security_tls_v1_2_server() # pylint: disable=W0212
 
     self.assertEqual(result, 'Feature Not Detected')
-    self.assertEqual(description, 'TLS 1.2 certificate could not be validated')
-    self.assertEqual(details, ['TLS 1.2 certificate could not be validated.'])
+    self.assertEqual(description, 'No outbound TLS connections detected')
+    self.assertEqual(details, ['No outbound TLS connections detected.'])
 
   @patch('tls_module.TLSUtil.validate_tls_server')
   def security_tls_v1_2_server_no_tls_v1_3_test(self, mock_validate_tls_server):
@@ -164,8 +164,8 @@ class TLSModuleTest(unittest.TestCase):
     result, description, details = self.tls_module._security_tls_v1_2_server() # pylint: disable=W0212
 
     self.assertEqual(result, 'Feature Not Detected')
-    self.assertEqual(description, 'TLS 1.2 certificate could not be validated')
-    self.assertEqual(details, ['TLS 1.2 certificate could not be validated.'])
+    self.assertEqual(description, 'No outbound TLS connections detected')
+    self.assertEqual(details, ['No outbound TLS connections detected.'])
 
   @patch('tls_module.TLSUtil.validate_tls_server')
   def security_tls_v1_2_server_invalid_v1_2_cert_test(self,
@@ -478,6 +478,40 @@ class TLSModuleTest(unittest.TestCase):
   def security_tls_v1_3_server_test(self):
     test_results = TLS_UTIL.validate_tls_server('google.com', tls_version='1.3')
     self.assertTrue(test_results[0])
+
+  def security_tls_v1_3_server_no_scan_results_test(self):
+    """Tests _security_tls_v1_3_server when scan finds no HTTP/HTTPS ports"""
+
+    self.tls_module._device_ipv4_addr = '10.10.10.14' # pylint: disable=W0212
+    self.tls_module._scan_results = {} # pylint: disable=W0212
+
+    result, description, details = self.tls_module._security_tls_v1_3_server() # pylint: disable=W0212
+
+    self.assertEqual(result, 'Feature Not Detected')
+    self.assertEqual(description, 'No outbound TLS connections detected')
+    self.assertEqual(details, ['No outbound TLS connections detected.'])
+
+  @patch('tls_module.TLSUtil.validate_tls_server')
+  def security_tls_v1_3_server_no_tls_v1_3_test(self, mock_validate_tls_server):
+    """Test _security_tls_v1_3_server when TLS 1.3 is not supported"""
+
+    self.tls_module._device_ipv4_addr = '10.10.10.14' # pylint: disable=W0212
+    self.tls_module._scan_results = {443 : 'HTTPS'} # pylint: disable=W0212
+
+    # Mock the result of validate_tls_server from TLSUtil
+    def validate_side_effect(**kwargs):
+      tls_version = kwargs.get('tls_version')
+      if tls_version == '1.3':
+        return (None, ['Failed to resolve public certificate'])
+      elif tls_version == '1.2':
+        return (True, ['Time range valid', 'Public key valid', 'Signature valid'])
+
+    mock_validate_tls_server.side_effect = validate_side_effect
+    result, description, details = self.tls_module._security_tls_v1_3_server() # pylint: disable=W0212
+
+    self.assertEqual(result, 'Feature Not Detected')
+    self.assertEqual(description, 'No outbound TLS connections detected')
+    self.assertEqual(details, ['No outbound TLS connections detected.'])
 
   def security_tls_v1_2_client_test(self):
     test_results = self.test_client_tls('1.2')
@@ -902,6 +936,10 @@ if __name__ == '__main__':
 
   # TLS 1.3 server tests
   suite.addTest(TLSModuleTest('security_tls_v1_3_server_test'))
+  suite.addTest(
+      TLSModuleTest('security_tls_v1_3_server_no_scan_results_test')
+  )
+  suite.addTest(TLSModuleTest('security_tls_v1_3_server_no_tls_v1_3_test'))
 
   # TLS client tests
   suite.addTest(TLSModuleTest('security_tls_v1_2_client_test'))


### PR DESCRIPTION
Fix TLS 1.3 server validation bug and change undetected TLS message to "No outbound TLS connections detected"