### PR TITLE
Add support for non-DHCP capable devices

### DIFF
--- a/framework/python/src/net_orc/arp_prober.py
+++ b/framework/python/src/net_orc/arp_prober.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cyclically probes the device interface with ARP requests so that a device
+under test configured with a static IP address (instead of using DHCP) can be
+detected during the 'waiting' phase.
+
+The prober only sends requests. Responses are detected by the existing network
+Listener, which fires an ARP_RESPONSE network event. This keeps a single packet
+receive path (the Listener) and avoids introducing additional sniffers."""
+import threading
+from scapy.all import ARP, Ether, sendp
+from common import logger
+
+LOGGER = logger.get_logger('arp_prober')
+
+# Mandated static IP address for devices that do not support DHCP. This falls
+# within the network range used by Testrun (10.10.10.0/24). Must stay in sync with
+# modules/test/conn/python/src/connection_module.py.STATIC_IP_ADDRESS.
+STATIC_IP_ADDRESS = '10.10.10.100'
+
+# Source identity for the probes. The probes are sent as the gateway network
+# container.
+ARP_PROBE_SRC_MAC = '9a:02:57:1e:8f:01'
+ARP_PROBE_SRC_IP = '10.10.10.1'
+
+# Interval, in seconds, between successive ARP probes.
+ARP_PROBE_INTERVAL = 1
+
+
+class ArpProber:
+  """Periodically sends ARP requests for the mandated static IP address on the
+  device interface, for the duration of the 'waiting' phase."""
+
+  def __init__(self,
+               device_intf,
+               target_ip=STATIC_IP_ADDRESS,
+               src_mac=ARP_PROBE_SRC_MAC,
+               src_ip=ARP_PROBE_SRC_IP,
+               interval=ARP_PROBE_INTERVAL):
+    self._device_intf = device_intf
+    self._target_ip = target_ip
+    self._src_mac = src_mac
+    self._src_ip = src_ip
+    self._interval = interval
+
+    self._stop_event = threading.Event()
+    self._thread = None
+
+    # A traditional broadcast ARP request ('who-has target_ip') sourced from a
+    # recognised network container.
+    self._probe = (
+        Ether(src=self._src_mac, dst='ff:ff:ff:ff:ff:ff') /
+        ARP(op=1,
+            hwsrc=self._src_mac,
+            psrc=self._src_ip,
+            pdst=self._target_ip))
+
+  def is_running(self):
+    """Determine whether the prober thread is active."""
+    return self._thread is not None and self._thread.is_alive()
+
+  def start(self):
+    """Start cyclically probing for the static IP address."""
+    if self.is_running():
+      LOGGER.debug('ARP prober was already running')
+      return
+    self._stop_event.clear()
+    self._thread = threading.Thread(target=self._probe_loop,
+                                    name='ARP prober',
+                                    daemon=True)
+    self._thread.start()
+    LOGGER.debug(
+        f'Started ARP prober for {self._target_ip} on {self._device_intf}')
+
+  def stop(self):
+    """Stop probing."""
+    self._stop_event.set()
+    thread = self._thread
+    # Never join from within the prober thread itself.
+    if thread is not None and thread is not threading.current_thread():
+      thread.join(timeout=self._interval + 1)
+      LOGGER.debug('Stopped the ARP prober')
+    self._thread = None
+
+  def _probe_loop(self):
+    while not self._stop_event.is_set():
+      try:
+        sendp(self._probe, iface=self._device_intf, verbose=False)
+      except Exception as e:  # pylint: disable=W0703
+        LOGGER.error(f'Error sending ARP probe: {e}')
+      # Interruptible wait so stop() takes effect promptly.
+      self._stop_event.wait(self._interval)

--- a/framework/python/src/net_orc/listener.py
+++ b/framework/python/src/net_orc/listener.py
@@ -15,9 +15,10 @@
 """Intercepts network traffic between network services and the device
 under test."""
 import threading
-from scapy.all import AsyncSniffer, DHCP, get_if_hwaddr
+from scapy.all import AsyncSniffer, ARP, DHCP, get_if_hwaddr
 from scapy.error import Scapy_Exception
 from net_orc.network_event import NetworkEvent
+from net_orc.arp_prober import STATIC_IP_ADDRESS
 from common import logger
 
 LOGGER = logger.get_logger('listener')
@@ -26,6 +27,7 @@ DHCP_DISCOVER = 1
 DHCP_OFFER = 2
 DHCP_REQUEST = 3
 DHCP_ACK = 5
+ARP_REPLY = 2
 CONTAINER_MAC_PREFIX = '9a:02:57:1e:8f'
 
 
@@ -87,6 +89,14 @@ class Listener:
     # DHCP ACK callback
     if DHCP in packet and self._get_dhcp_type(packet) == DHCP_ACK:
       self.call_callback(NetworkEvent.DHCP_LEASE_ACK, packet)
+
+    # ARP probe response callback (static IP device detection). Fires when a
+    # device replies to the ARP request claiming the mandated static IP address.
+    # The responder's hardware address is validated against the configured
+    # target device by the registered callback.
+    if (ARP in packet and packet[ARP].op == ARP_REPLY
+        and packet[ARP].psrc == STATIC_IP_ADDRESS):
+      self.call_callback(NetworkEvent.ARP_RESPONSE, packet[ARP].hwsrc)
 
     # New device discovered callback
     if not packet.src is None and packet.src not in self._discovered_devices:

--- a/framework/python/src/net_orc/network_event.py
+++ b/framework/python/src/net_orc/network_event.py
@@ -21,3 +21,4 @@ class NetworkEvent(Enum):
   DEVICE_DISCOVERED = 1
   DEVICE_STABLE = 2
   DHCP_LEASE_ACK = 3
+  ARP_RESPONSE = 4

--- a/framework/python/src/net_orc/network_orchestrator.py
+++ b/framework/python/src/net_orc/network_orchestrator.py
@@ -28,6 +28,7 @@ from common import logger, util, mqtt
 from common.statuses import TestrunStatus
 from net_orc.listener import Listener
 from net_orc.network_event import NetworkEvent
+from net_orc.arp_prober import ArpProber, STATIC_IP_ADDRESS
 from net_orc.network_validator import NetworkValidator
 from net_orc.ovs_control import OVSControl
 from net_orc.ip_control import IPControl
@@ -57,6 +58,7 @@ class NetworkOrchestrator:
     self._monitor_in_progress = False
     self._monitor_packets = []
     self._listener = None
+    self._arp_prober = None
     self._net_modules = []
 
     self._path = os.path.dirname(
@@ -159,6 +161,10 @@ class NetworkOrchestrator:
   def start_listener(self):
     LOGGER.debug('Starting network listener')
     self.get_listener().start_listener()
+    # Begin probing for statically addressed devices in parallel with the
+    # listener's DHCP-based detection.
+    if self._arp_prober is not None:
+      self._arp_prober.start()
 
   def stop(self, kill=False):
     """Stop the network orchestrator."""
@@ -202,6 +208,13 @@ class NetworkOrchestrator:
       # Ignore device if not registered
       return
 
+    # Clear any IP address carried over from a previous run. ip_addr persists on
+    # the device object across runs and is never otherwise reset, so a stale
+    # value would cause _device_has_ip to short-circuit the waiting phase before
+    # this run's DHCP lease or ARP probe response is observed. Resetting here
+    # ensures the transition to monitoring reflects only this-run detection.
+    device.ip_addr = None
+
     # Cleanup any old test files
     test_dir = os.path.join(RUNTIME_DIR, TEST_DIR)
     device_tests = os.listdir(test_dir)
@@ -219,6 +232,12 @@ class NetworkOrchestrator:
     packet_capture = sniff(iface=self._session.get_device_interface(),
                            timeout=self._session.get_startup_timeout(),
                            stop_filter=self._device_has_ip)
+
+    # The waiting phase has ended for this device (it obtained an IP or timed
+    # out), so stop probing.
+    if self._arp_prober is not None:
+      self._arp_prober.stop()
+
     wrpcap(os.path.join(device_runtime_dir, 'startup.pcap'), packet_capture)
 
     # Copy the device config file to the runtime directory
@@ -294,6 +313,30 @@ class NetworkOrchestrator:
 
     # TODO: Check if device is None
     device.ip_addr = packet[BOOTP].yiaddr
+
+  def _arp_response(self, hwsrc):
+    """Handle a device that answered our ARP probe for the mandated static IP
+    address. Mirrors _dhcp_lease_ack: assigns the static IP to the matching
+    registered device so the waiting phase can complete just as it would for a
+    device that obtained its address via DHCP."""
+    device = self._session.get_device(mac_addr=hwsrc)
+
+    # Ignore responses from devices that are not registered
+    if device is None:
+      return
+
+    # Only progress for the device the user configured. If the responder's MAC
+    # does not match the configured target MAC, do not assign the static IP.
+    target = self._session.get_target_device()
+    if target is not None and hwsrc.lower() != target.mac_addr.lower():
+      return
+
+    # Assign the mandated static IP once. The waiting-phase stop filter
+    # (_device_has_ip) detects this and the flow proceeds to monitoring.
+    if device.ip_addr is None:
+      device.ip_addr = STATIC_IP_ADDRESS
+      LOGGER.info(f'Device with mac addr {device.mac_addr} responded to ARP '
+                  f'probe with static IP address {STATIC_IP_ADDRESS}')
 
   def _start_device_monitor(self, device):
     """Start a timer until the steady state has been reached and
@@ -436,6 +479,11 @@ class NetworkOrchestrator:
                                           [NetworkEvent.DEVICE_DISCOVERED])
     self.get_listener().register_callback(self._dhcp_lease_ack,
                                           [NetworkEvent.DHCP_LEASE_ACK])
+    self.get_listener().register_callback(self._arp_response,
+                                          [NetworkEvent.ARP_RESPONSE])
+
+    # Prober for detecting devices configured with a static IP address
+    self._arp_prober = ArpProber(self._session.get_device_interface())
 
   def load_network_modules(self):
     """Load network modules from module_config.json."""
@@ -668,6 +716,11 @@ class NetworkOrchestrator:
   def restore_net(self):
 
     LOGGER.info('Clearing baseline network')
+
+    # Stop probing if it is still active (e.g. cancelled before a device was
+    # discovered).
+    if self._arp_prober is not None:
+      self._arp_prober.stop()
 
     if self.get_listener() is not None and self.get_listener().is_running():
       self.get_listener().stop_listener()

--- a/modules/test/conn/python/src/connection_module.py
+++ b/modules/test/conn/python/src/connection_module.py
@@ -17,8 +17,9 @@ import time
 import traceback
 import os
 from scapy.error import Scapy_Exception
-from scapy.all import rdpcap, DHCP, ARP, Ether, ICMP, IPv6, ICMPv6ND_NS
+from scapy.all import rdpcap, srp, get_if_addr, DHCP, ARP, Ether, ICMP, IPv6, ICMPv6ND_NS
 from test_module import TestModule
+from common.statuses import TestResult
 from dhcp1.client import Client as DHCPClient1
 from dhcp2.client import Client as DHCPClient2
 from host.client import Client as HostClient
@@ -34,6 +35,11 @@ MONITOR_CAPTURE_FILE = '/runtime/device/monitor.pcap'
 DHCP_CAPTURE_FILE = '/runtime/network/dhcp-1.pcap'
 SLAAC_PREFIX = 'fd10:77be:4186'
 TR_CONTAINER_MAC_PREFIX = '9a:02:57:1e:8f:'
+
+# Fixed static IP address probed for during startup to detect devices that do
+# not implement DHCP. Must stay in sync with
+# framework/python/src/net_orc/arp_prober.py.STATIC_IP_ADDRESS.
+STATIC_IP_ADDRESS = '10.10.10.100'
 LOGGER = None
 
 # Should be at least twice as much as the max lease time
@@ -118,24 +124,21 @@ class ConnectionModule(TestModule):
       LOGGER.error('No device IP could be resolved')
       return 'Error', 'Could not resolve device IP address'
 
-    no_arp = True
-
-    # Read all the pcap files
+    # Read all the pcap files and collect ARP packets sent by the device
     packets = rdpcap(self.startup_capture_file) + rdpcap(
         self.monitor_capture_file)
-    for packet in packets:
+    device_arp = [packet[ARP] for packet in packets
+                  if ARP in packet and packet.src == self._device_mac]
 
-      # We are not interested in packets unless they are ARP packets
-      if not ARP in packet:
-        continue
+    # Some resource-constrained devices do not volunteer ARP traffic, so if
+    # none were captured, actively solicit a reply (retrying a few times)
+    if not device_arp:
+      device_arp = self._solicit_arp()
 
-      # We are only interested in packets from the device
-      if packet.src != self._device_mac:
-        continue
+    if not device_arp:
+      return None, 'No ARP packets from the device found'
 
-      # Get the ARP packet
-      arp_packet = packet[ARP]
-      no_arp = False
+    for arp_packet in device_arp:
 
       # Check MAC address matches IP address
       if (arp_packet.hwsrc == self._device_mac
@@ -146,10 +149,39 @@ class ConnectionModule(TestModule):
                     does not match {self._device_ipv4_addr}''')
         return False, 'Device is sending false ARP response'
 
-    if no_arp:
-      return None, 'No ARP packets from the device found'
-
     return True, 'Device uses ARP correctly'
+
+  def _solicit_arp(self, retries=3, timeout=3):
+    """Actively solicit an ARP reply from the device.
+
+    Some devices do not volunteer ARP traffic during the capture window,
+    leaving the passive inspection with nothing to assess. Send an ARP
+    request for the device IP, retrying a few times before giving up.
+
+    Returns a list of ARP packets received from the device (empty if none).
+    """
+    request = (Ether(dst='ff:ff:ff:ff:ff:ff')
+               / ARP(op=1, psrc=get_if_addr('veth0'),
+                     pdst=self._device_ipv4_addr))
+
+    for attempt in range(1, retries + 1):
+      LOGGER.info(f'Soliciting ARP from device {self._device_ipv4_addr} '
+                  f'(attempt {attempt}/{retries})')
+      try:
+        answered, _ = srp(request, iface='veth0', timeout=timeout,
+                          verbose=False)
+      except Exception as e:  # pylint: disable=W0718
+        LOGGER.error(f'ARP solicitation failed: {e}')
+        return []
+
+      replies = [received[ARP] for _, received in answered
+                 if ARP in received and received.src == self._device_mac]
+      if replies:
+        LOGGER.info('Received ARP reply from device')
+        return replies
+
+    LOGGER.info(f'No ARP reply received from device after {retries} attempts')
+    return []
 
   def _connection_switch_dhcp_snooping(self):
     LOGGER.info('Running connection.switch.dhcp_snooping')
@@ -182,14 +214,23 @@ class ConnectionModule(TestModule):
 
   def _connection_private_address(self, config):
     LOGGER.info('Running connection.private_address')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     return self._run_subnet_test(config)
 
   def _connection_shared_address(self, config):
     LOGGER.info('Running connection.shared_address')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     return self._run_subnet_test(config)
 
   def _connection_dhcp_address(self):
     LOGGER.info('Running connection.dhcp_address')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     lease = self._dhcp_util.get_cur_lease(mac_address=self._device_mac,
                                           timeout=self._lease_wait_time_sec)
     if lease is None:
@@ -232,6 +273,10 @@ class ConnectionModule(TestModule):
 
   def _connection_single_ip(self):
     LOGGER.info('Running connection.single_ip')
+
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
 
     result = None
     if self._device_mac is None:
@@ -291,6 +336,9 @@ class ConnectionModule(TestModule):
 
   def _connection_ipaddr_ip_change(self, config):
     LOGGER.info('Running connection.ipaddr.ip_change')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     # Resolve the configured lease wait time
     if (not 'lease_wait_time_sec' in config or
       not self._dhcp_util.setup_single_dhcp_server()):
@@ -336,6 +384,9 @@ class ConnectionModule(TestModule):
 
   def _connection_ipaddr_dhcp_failover(self, config):
     LOGGER.info('Running connection.ipaddr.dhcp_failover')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     # Resolve the configured lease wait time
     if 'lease_wait_time_sec' in config:
       self._lease_wait_time_sec = config['lease_wait_time_sec']
@@ -376,6 +427,9 @@ class ConnectionModule(TestModule):
 
   def _connection_dhcp_disconnect(self) -> tuple[str | bool, str]:
     LOGGER.info('Running connection.dhcp.disconnect')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     dev_iface = os.getenv('DEV_IFACE')
     rpc_error_msg = 'Unable to connect to gRPC server'
     try:
@@ -431,6 +485,9 @@ class ConnectionModule(TestModule):
 
   def _connection_dhcp_disconnect_ip_change(self):
     LOGGER.info('Running connection.dhcp.disconnect_ip_change')
+    if self._is_static_ip_device():
+      return (TestResult.FEATURE_NOT_DETECTED,
+              'Device does not support DHCP so this test could not be run')
     result = None
     description = ''
     reserved_lease = None
@@ -600,6 +657,32 @@ class ConnectionModule(TestModule):
   def _ping(self, host, ipv6=False):
     LOGGER.info('Pinging: ' + str(host))
     return self._dhcp_util.ping(host, ipv6=ipv6)
+
+  def _is_static_ip_device(self):
+    """Return True when the device is reachable at the mandated static IP
+    address but has not obtained a DHCP lease.
+
+    Devices that do not implement DHCP are detected during startup by the
+    network orchestrator's ARP probe and assigned the fixed static IP
+    address (STATIC_IP_ADDRESS). The DHCP-dependent tests cannot exercise
+    their behaviour against such a device, so this signal is used to
+    short-circuit those tests to a 'Feature Not Detected' result rather than
+    erroring on an absent lease.
+    """
+    # Lazily resolve the device IP, mirroring the other tests
+    if self._device_ipv4_addr is None:
+      self._device_ipv4_addr = self._get_device_ipv4()
+
+    # Not on the static IP -> treat as a normal (DHCP) device and run the
+    # test as usual.
+    if self._device_ipv4_addr != STATIC_IP_ADDRESS:
+      return False
+
+    # A device that also holds a DHCP lease is not a static-only device.
+    # timeout=0 performs a single lease query with no waiting.
+    lease = self._dhcp_util.get_cur_lease(mac_address=self._device_mac,
+                                          timeout=0)
+    return lease is None
 
   def restore_failover_dhcp_server(self, subnet):
     # Configure the subnet range

--- a/modules/ui/src/app/pages/testrun/components/testrun-initiate-form/testrun-initiate-form.component.html
+++ b/modules/ui/src/app/pages/testrun/components/testrun-initiate-form/testrun-initiate-form.component.html
@@ -71,7 +71,9 @@ limitations under the License.
       }
       @if (selectedDevice !== null) {
         <app-callout [type]="CalloutType.Info" role="note">
-          Top Tip: Your device must be powered off before starting Testrun
+          Top Tip: Your device must be powered off and DHCP must be enabled before starting the test. If your device
+          doesn't support DHCP then it should be configured with a static IP address of 10.10.10.100, a subnet mask of
+          255.255.255.0, and a default gateway IP address of 10.10.10.1.
         </app-callout>
       }
     </section>


### PR DESCRIPTION
This feature adds support for non-DHCP devices to progress to the Monitoring phase by soliciting an ARP response from a hardcoded, pre-specified to the end user, IP address of 10.10.10.100/24.

<img width="550" height="523" alt="image" src="https://github.com/user-attachments/assets/9300cdf5-636c-45f7-9e86-7c0615230075" />

The DHCP related tests are duly not run if a non-DHCP device is detected.

<img width="970" height="473" alt="image" src="https://github.com/user-attachments/assets/e5e4dfff-8217-4a14-a5e2-cd11f85e6fe7" />

DHCP devices are unaffected and still able to progress to Monitoring as normal if detected.