### PR TITLE
Prevent scheduler "missed run time" warnings for periodic checkers

### DIFF
--- a/framework/python/src/common/tasks.py
+++ b/framework/python/src/common/tasks.py
@@ -53,6 +53,9 @@ class PeriodicTasks:
                 },
         trigger='interval',
         seconds=CHECK_NETWORK_ADAPTERS_PERIOD,
+        misfire_grace_time=None,
+        coalesce=True,
+        max_instances=1,
     )
     # add internet connection cheking job only in single-intf mode
     if 'single_intf' not in self._testrun.get_session().get_runtime_params():
@@ -64,6 +67,9 @@ class PeriodicTasks:
                   },
           trigger='interval',
           seconds=CHECK_INTERNET_PERIOD,
+          misfire_grace_time=None,
+          coalesce=True,
+          max_instances=1,
       )
 
   @asynccontextmanager

--- a/framework/python/src/core/tasks.py
+++ b/framework/python/src/core/tasks.py
@@ -51,6 +51,9 @@ class PeriodicTasks:
                 },
         trigger='interval',
         seconds=CHECK_NETWORK_ADAPTERS_PERIOD,
+        misfire_grace_time=None,
+        coalesce=True,
+        max_instances=1,
     )
     # add internet connection cheking job only in single-intf mode
     if 'single_intf' not in self._testrun.get_session().get_runtime_params():
@@ -62,6 +65,9 @@ class PeriodicTasks:
                   },
           trigger='interval',
           seconds=CHECK_INTERNET_PERIOD,
+          misfire_grace_time=None,
+          coalesce=True,
+          max_instances=1,
       )
 
   @asynccontextmanager


### PR DESCRIPTION
The network adapter and internet connection checkers run on short intervals (5s and 2s). APScheduler's default misfire_grace_time of 1 second means any run serviced slightly late is logged as missed, e.g. "Run time of job 'NetworkOrchestrator.network_adapters_checker' was missed by 0:00:02". These are harmless status pollers, so a late run is not a real problem.

Set misfire_grace_time=None so late runs always execute instead of being reported as missed, coalesce=True to collapse backed-up runs, and max_instances=1 to avoid overlapping executions.

Fixes #1519